### PR TITLE
feat(language): add node to object mapping with zod schemas

### DIFF
--- a/libs/language/eslint.config.js
+++ b/libs/language/eslint.config.js
@@ -28,4 +28,7 @@ module.exports = [
       parser: require('jsonc-eslint-parser'),
     },
   },
+  {
+    ignores: ['scripts/benchmark/data/**'],
+  },
 ];

--- a/libs/language/src/lib/index.ts
+++ b/libs/language/src/lib/index.ts
@@ -1,2 +1,3 @@
 export * from './model';
 export * from './utils';
+export * from './mapping';

--- a/libs/language/src/lib/mapping/AnyConverter.ts
+++ b/libs/language/src/lib/mapping/AnyConverter.ts
@@ -1,0 +1,8 @@
+import { BlueNode } from '../model';
+import { Converter } from './Converter';
+
+export class AnyConverter implements Converter {
+  convert(node: BlueNode) {
+    return node;
+  }
+}

--- a/libs/language/src/lib/mapping/ArrayConverter.ts
+++ b/libs/language/src/lib/mapping/ArrayConverter.ts
@@ -1,0 +1,24 @@
+import { BlueNode } from '../model';
+import { Converter } from './Converter';
+import { NodeToObjectConverter } from './NodeToObjectConverter';
+import { ArrayCardinality, arrayOutputType, ZodArray, ZodTypeAny } from 'zod';
+
+export class ArrayConverter implements Converter {
+  constructor(private readonly nodeToObjectConverter: NodeToObjectConverter) {}
+
+  convert<T extends ZodTypeAny, Cardinality extends ArrayCardinality = 'many'>(
+    node: BlueNode,
+    targetType: ZodArray<T, Cardinality>
+  ) {
+    const items = node.getItems();
+    if (!items) {
+      return undefined;
+    }
+
+    const elementSchema = targetType.element;
+    const result = items.map((item) =>
+      this.nodeToObjectConverter.convert(item, elementSchema)
+    );
+    return result as arrayOutputType<T, Cardinality>;
+  }
+}

--- a/libs/language/src/lib/mapping/ComplexObjectConverter.ts
+++ b/libs/language/src/lib/mapping/ComplexObjectConverter.ts
@@ -1,0 +1,128 @@
+import {
+  ZodIntersection,
+  ZodObject,
+  ZodObjectDef,
+  ZodType,
+  ZodUnion,
+} from 'zod';
+import { BlueNode } from '../model';
+import { BlueIdCalculator } from '../utils';
+import { isNonNullable, isNullable } from '@blue-company/shared-utils';
+import {
+  getBlueDescriptionAnnotation,
+  getBlueIdAnnotation,
+  getBlueNameAnnotation,
+} from './annotations';
+import { isString } from 'radash';
+import { Converter } from './Converter';
+import {
+  ZodRawShape,
+  ZodTypeAny,
+  objectOutputType,
+  objectInputType,
+  UnknownKeysParam,
+} from 'zod';
+import { NodeToObjectConverter } from './NodeToObjectConverter';
+
+export class ComplexObjectConverter implements Converter {
+  constructor(private readonly nodeToObjectConverter: NodeToObjectConverter) {}
+
+  public convert<
+    T extends ZodRawShape,
+    UnknownKeys extends UnknownKeysParam = UnknownKeysParam,
+    Catchall extends ZodTypeAny = ZodTypeAny,
+    Output = objectOutputType<T, Catchall, UnknownKeys>,
+    Input = objectInputType<T, Catchall, UnknownKeys>
+  >(
+    node: BlueNode,
+    targetType: ZodType<Output, ZodObjectDef<T, UnknownKeys, Catchall>, Input>
+  ) {
+    return this.convertFields(node, targetType) as Output;
+  }
+
+  private convertFields(node: BlueNode, schema: ZodTypeAny): unknown {
+    if (schema instanceof ZodIntersection) {
+      const left = schema._def.left;
+      const right = schema._def.right;
+
+      const leftResult = this.convert(node, left);
+      const rightResult = this.convert(node, right);
+
+      return { ...leftResult, ...rightResult };
+    }
+
+    if (schema instanceof ZodUnion) {
+      throw new Error('Union not supported');
+    }
+
+    if (schema instanceof ZodObject) {
+      const result = Object.keys(schema.shape).reduce((acc, propertyName) => {
+        const properties = node.getProperties();
+        const schemaProperty = schema.shape[propertyName];
+
+        const blueIdAnnotation = getBlueIdAnnotation(schemaProperty);
+        if (isNonNullable(blueIdAnnotation)) {
+          const propertyNameWithAnnotation = isString(blueIdAnnotation)
+            ? blueIdAnnotation
+            : propertyName;
+
+          const propertyNode = properties?.[propertyNameWithAnnotation];
+          const blueId = propertyNode
+            ? BlueIdCalculator.calculateBlueIdSync(propertyNode)
+            : undefined;
+
+          acc[propertyName] = blueId;
+
+          return acc;
+        }
+
+        const blueNameAnnotation = getBlueNameAnnotation(schemaProperty);
+        if (isNonNullable(blueNameAnnotation)) {
+          const propertyNode = properties?.[blueNameAnnotation];
+          acc[propertyName] = propertyNode?.getName();
+          return acc;
+        }
+
+        const blueDescriptionAnnotation =
+          getBlueDescriptionAnnotation(schemaProperty);
+        if (isNonNullable(blueDescriptionAnnotation)) {
+          const propertyNode = properties?.[blueDescriptionAnnotation];
+          acc[propertyName] = propertyNode?.getDescription();
+          return acc;
+        }
+
+        if (propertyName === 'name') {
+          const name = node.getName();
+          acc[propertyName] = name;
+
+          return acc;
+        }
+
+        if (propertyName === 'description') {
+          const description = node.getDescription();
+          acc[propertyName] = description;
+
+          return acc;
+        }
+
+        const propertyNode = properties?.[propertyName];
+
+        if (isNullable(propertyNode)) {
+          return acc;
+        }
+
+        const converted = this.nodeToObjectConverter.convert(
+          propertyNode,
+          schemaProperty
+        );
+        acc[propertyName] = converted;
+
+        return acc;
+      }, {} as Record<string, unknown>);
+
+      return result;
+    }
+
+    throw new Error('Unknown schema type, ' + schema.constructor.name);
+  }
+}

--- a/libs/language/src/lib/mapping/Converter.ts
+++ b/libs/language/src/lib/mapping/Converter.ts
@@ -1,0 +1,6 @@
+import { ZodTypeAny } from 'zod';
+import { BlueNode } from '../model';
+
+export interface Converter {
+  convert(node: BlueNode, targetType: ZodTypeAny): unknown;
+}

--- a/libs/language/src/lib/mapping/ConverterFactory.ts
+++ b/libs/language/src/lib/mapping/ConverterFactory.ts
@@ -1,0 +1,116 @@
+import { Converter } from './Converter';
+import { PrimitiveConverter } from './PrimitiveConverter';
+import { ComplexObjectConverter } from './ComplexObjectConverter';
+import { ArrayConverter } from './ArrayConverter';
+import { SetConverter } from './SetConverter';
+import { MapConverter } from './MapConverter';
+import {
+  z,
+  ZodTypeAny,
+  ZodNullable,
+  ZodReadonly,
+  ZodBranded,
+  ZodLazy,
+  ZodEffects,
+  ZodOptional,
+  ZodType,
+} from 'zod';
+import { NodeToObjectConverter } from './NodeToObjectConverter';
+import { UnknownConverter } from './UnknownConverter';
+import { AnyConverter } from './AnyConverter';
+
+const zodSchemaTypeNamesSchema = z.union([
+  z.literal('ZodString'),
+  z.literal('ZodNumber'),
+  z.literal('ZodBoolean'),
+  z.literal('ZodBigInt'),
+  z.literal('ZodArray'),
+  z.literal('ZodSet'),
+  z.literal('ZodMap'),
+  z.literal('ZodRecord'),
+  z.literal('ZodObject'),
+  z.literal('ZodEnum'),
+  z.literal('ZodNativeEnum'),
+  z.literal('ZodUnknown'),
+  z.literal('ZodAny'),
+]);
+
+type ZodSchemaTypeNames = z.infer<typeof zodSchemaTypeNamesSchema>;
+
+export class ConverterFactory {
+  private readonly converters = new Map<ZodSchemaTypeNames, Converter>();
+  private readonly complexObjectConverter: ComplexObjectConverter;
+
+  constructor(private readonly nodeToObjectConverter: NodeToObjectConverter) {
+    this.registerConverters();
+
+    this.complexObjectConverter = new ComplexObjectConverter(
+      this.nodeToObjectConverter
+    );
+  }
+
+  private registerConverters() {
+    const primitiveConverter = new PrimitiveConverter();
+    const arrayConverter = new ArrayConverter(this.nodeToObjectConverter);
+    const setConverter = new SetConverter(this.nodeToObjectConverter);
+    const mapConverter = new MapConverter(this.nodeToObjectConverter);
+
+    // Register primitive type converters
+    this.converters.set('ZodString', primitiveConverter);
+    this.converters.set('ZodNumber', primitiveConverter);
+    this.converters.set('ZodBoolean', primitiveConverter);
+    this.converters.set('ZodBigInt', primitiveConverter);
+    this.converters.set('ZodEnum', primitiveConverter);
+    this.converters.set('ZodNativeEnum', primitiveConverter);
+
+    // Register unknown converter
+    this.converters.set('ZodUnknown', new UnknownConverter());
+
+    // Register any converter
+    this.converters.set('ZodAny', new AnyConverter());
+
+    // Register collection converters
+    this.converters.set('ZodArray', arrayConverter);
+    this.converters.set('ZodSet', setConverter);
+    this.converters.set('ZodMap', mapConverter);
+    this.converters.set('ZodRecord', mapConverter);
+
+    // Register object converter as default
+    this.converters.set('ZodObject', this.complexObjectConverter);
+  }
+
+  getConverter(targetType: ZodTypeAny): Converter {
+    const schemaTargetTypeName = this.getSchemaTypeName(targetType);
+
+    return (
+      this.converters.get(schemaTargetTypeName) ?? this.complexObjectConverter
+    );
+  }
+
+  private isWrapperType(schema: ZodType) {
+    return (
+      schema instanceof ZodOptional ||
+      schema instanceof ZodNullable ||
+      schema instanceof ZodReadonly ||
+      schema instanceof ZodBranded ||
+      schema instanceof ZodEffects ||
+      schema instanceof ZodLazy
+    );
+  }
+
+  private getSchemaTypeName(schema: ZodTypeAny): ZodSchemaTypeNames {
+    if (this.isWrapperType(schema)) {
+      if (schema instanceof ZodEffects) {
+        return this.getSchemaTypeName(schema.innerType());
+      }
+      if (schema instanceof ZodLazy) {
+        return this.getSchemaTypeName(schema.schema);
+      }
+      return this.getSchemaTypeName(schema.unwrap());
+    }
+
+    const schemaTypeName = schema.constructor.name;
+    const parsedSchemaTypeName = zodSchemaTypeNamesSchema.parse(schemaTypeName);
+    return parsedSchemaTypeName;
+  }
+}

--- a/libs/language/src/lib/mapping/MapConverter.ts
+++ b/libs/language/src/lib/mapping/MapConverter.ts
@@ -1,0 +1,49 @@
+import { ZodMap, ZodRecord } from 'zod';
+import { BlueNode } from '../model';
+import { Converter } from './Converter';
+import { NodeToObjectConverter } from './NodeToObjectConverter';
+import { isNonNullable } from '@blue-company/shared-utils';
+import { ValueConverter } from './ValueConverter';
+import { TEXT_TYPE_BLUE_ID } from '../utils/Properties';
+
+export class MapConverter implements Converter {
+  constructor(private readonly nodeToObjectConverter: NodeToObjectConverter) {}
+
+  convert(node: BlueNode, targetType: ZodRecord | ZodMap) {
+    const keySchema = targetType.keySchema;
+    const valueSchema = targetType.valueSchema;
+
+    const result = new Map<unknown, unknown>();
+
+    const nodeName = node.getName();
+    if (isNonNullable(nodeName)) {
+      result.set('name', nodeName);
+    }
+
+    const nodeDescription = node.getDescription();
+    if (isNonNullable(nodeDescription)) {
+      result.set('description', nodeDescription);
+    }
+
+    const properties = node.getProperties();
+    if (isNonNullable(properties)) {
+      Object.entries(properties).forEach(([key, property]) => {
+        const keyNode = new BlueNode().setValue(key);
+        keyNode.setType(new BlueNode().setBlueId(TEXT_TYPE_BLUE_ID));
+
+        const keyConverted = ValueConverter.convertValue(keyNode, keySchema);
+        const value = this.nodeToObjectConverter.convert(property, valueSchema);
+        result.set(keyConverted, value);
+      });
+    }
+
+    if (targetType instanceof ZodRecord) {
+      return Object.fromEntries(result) as Record<
+        string | number | symbol,
+        unknown
+      >;
+    }
+
+    return result;
+  }
+}

--- a/libs/language/src/lib/mapping/NodeToObjectConverter.ts
+++ b/libs/language/src/lib/mapping/NodeToObjectConverter.ts
@@ -1,0 +1,78 @@
+import {
+  ZodEffects,
+  ZodLazy,
+  ZodType,
+  ZodBranded,
+  ZodNullable,
+  ZodOptional,
+  ZodReadonly,
+  ZodTypeAny,
+} from 'zod';
+import { ZodTypeDef } from 'zod';
+import { BlueNode } from '../model';
+import { TypeSchemaResolver } from '../utils/TypeSchemaResolver';
+import { ConverterFactory } from './ConverterFactory';
+import { isNonNullable } from '@blue-company/shared-utils';
+import { isSchemaExtendedFrom } from './annotations';
+
+export class NodeToObjectConverter {
+  private readonly converterFactory: ConverterFactory;
+
+  constructor(private typeSchemaResolver: TypeSchemaResolver) {
+    this.converterFactory = new ConverterFactory(this);
+  }
+
+  convert<
+    Output = unknown,
+    Def extends ZodTypeDef = ZodTypeDef,
+    Input = Output
+  >(node: BlueNode, targetType: ZodType<Output, Def, Input>): Output {
+    const resolvedSchema = this.typeSchemaResolver.resolveSchema(node);
+    const unwrappedTargetType = this.unwrapSchema(targetType);
+
+    let schemaToUse = unwrappedTargetType;
+
+    if (
+      isNonNullable(resolvedSchema) &&
+      isSchemaExtendedFrom(resolvedSchema, unwrappedTargetType)
+    ) {
+      schemaToUse = resolvedSchema;
+    }
+
+    return this.convertWithType(node, schemaToUse);
+  }
+
+  private convertWithType<
+    Output = unknown,
+    Def extends ZodTypeDef = ZodTypeDef,
+    Input = Output
+  >(node: BlueNode, targetType: ZodType<Output, Def, Input>): Output {
+    const converter = this.converterFactory.getConverter(targetType);
+    return converter.convert(node, targetType) as Output;
+  }
+
+  private isWrapperType(schema: ZodType) {
+    return (
+      schema instanceof ZodOptional ||
+      schema instanceof ZodNullable ||
+      schema instanceof ZodReadonly ||
+      schema instanceof ZodBranded ||
+      schema instanceof ZodEffects ||
+      schema instanceof ZodLazy
+    );
+  }
+
+  private unwrapSchema(schema: ZodTypeAny): ZodTypeAny {
+    if (this.isWrapperType(schema)) {
+      if (schema instanceof ZodEffects) {
+        return this.unwrapSchema(schema.innerType());
+      }
+      if (schema instanceof ZodLazy) {
+        return this.unwrapSchema(schema.schema);
+      }
+      return this.unwrapSchema(schema.unwrap());
+    }
+
+    return schema;
+  }
+}

--- a/libs/language/src/lib/mapping/NullConverter.ts
+++ b/libs/language/src/lib/mapping/NullConverter.ts
@@ -1,0 +1,7 @@
+import { Converter } from './Converter';
+
+export class NullConverter implements Converter {
+  convert() {
+    return null;
+  }
+}

--- a/libs/language/src/lib/mapping/PrimitiveConverter.ts
+++ b/libs/language/src/lib/mapping/PrimitiveConverter.ts
@@ -1,0 +1,28 @@
+import {
+  ZodBoolean,
+  ZodBigInt,
+  ZodNumber,
+  ZodString,
+  ZodEnum,
+  ZodNativeEnum,
+} from 'zod';
+import { BlueNode } from '../model';
+import { Converter } from './Converter';
+import { ValueConverter } from './ValueConverter';
+
+export class PrimitiveConverter implements Converter {
+  convert(
+    node: BlueNode,
+    targetType:
+      | ZodString
+      | ZodNumber
+      | ZodBoolean
+      | ZodBigInt
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      | ZodEnum<any>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      | ZodNativeEnum<any>
+  ) {
+    return ValueConverter.convertValue(node, targetType);
+  }
+}

--- a/libs/language/src/lib/mapping/SetConverter.ts
+++ b/libs/language/src/lib/mapping/SetConverter.ts
@@ -1,0 +1,23 @@
+import { BlueNode } from '../model';
+import { Converter } from './Converter';
+import { NodeToObjectConverter } from './NodeToObjectConverter';
+import { ZodSet, ZodTypeAny } from 'zod';
+
+export class SetConverter implements Converter {
+  constructor(private readonly nodeToObjectConverter: NodeToObjectConverter) {}
+
+  convert<Value extends ZodTypeAny = ZodTypeAny>(
+    node: BlueNode,
+    targetType: ZodSet<Value>
+  ) {
+    const items = node.getItems();
+    if (!items) {
+      return undefined;
+    }
+    const elementSchema = targetType._def.valueType;
+    const result = items.map((item) =>
+      this.nodeToObjectConverter.convert(item, elementSchema)
+    );
+    return new Set(result) as Set<Value['_output']>;
+  }
+}

--- a/libs/language/src/lib/mapping/UnknownConverter.ts
+++ b/libs/language/src/lib/mapping/UnknownConverter.ts
@@ -1,0 +1,9 @@
+import { BlueNode } from '../model';
+import { NodeToMapListOrValue } from '../utils/NodeToMapListOrValue';
+import { Converter } from './Converter';
+
+export class UnknownConverter implements Converter {
+  convert(node: BlueNode) {
+    return NodeToMapListOrValue.get(node);
+  }
+}

--- a/libs/language/src/lib/mapping/ValueConverter.ts
+++ b/libs/language/src/lib/mapping/ValueConverter.ts
@@ -1,0 +1,174 @@
+import {
+  ZodString,
+  ZodNumber,
+  ZodBigInt,
+  ZodBoolean,
+  ZodTypeAny,
+  ZodEnum,
+  ZodNativeEnum,
+} from 'zod';
+import { BigDecimalNumber, BigIntegerNumber, BlueNode } from '../model';
+import {
+  TEXT_TYPE_BLUE_ID,
+  DOUBLE_TYPE_BLUE_ID,
+  INTEGER_TYPE_BLUE_ID,
+  BOOLEAN_TYPE_BLUE_ID,
+} from '../utils/Properties';
+import { isNullable } from '@blue-company/shared-utils';
+
+export class ValueConverter {
+  static convertValue(node: BlueNode, targetSchema: ZodTypeAny) {
+    const typeBlueId = node.getType()?.getBlueId();
+    const value = node.getValue();
+    if (isNullable(value)) {
+      if (this.isPrimitive(targetSchema)) {
+        return this.getDefaultPrimitiveValue(targetSchema);
+      }
+      return value;
+    }
+
+    if (TEXT_TYPE_BLUE_ID === typeBlueId) {
+      return this.convertFromString(String(value), targetSchema);
+    } else if (
+      DOUBLE_TYPE_BLUE_ID === typeBlueId ||
+      value instanceof BigDecimalNumber
+    ) {
+      return this.convertFromBigDecimal(
+        new BigDecimalNumber(value?.toString()),
+        targetSchema
+      );
+    } else if (
+      INTEGER_TYPE_BLUE_ID === typeBlueId ||
+      value instanceof BigIntegerNumber
+    ) {
+      return this.convertFromBigInteger(
+        new BigIntegerNumber(value?.toString()),
+        targetSchema
+      );
+    } else if (
+      BOOLEAN_TYPE_BLUE_ID === typeBlueId ||
+      typeof value === 'boolean'
+    ) {
+      return this.convertFromBoolean(Boolean(value), targetSchema);
+    }
+
+    return this.convertFromString(String(value), targetSchema);
+  }
+
+  private static convertFromString(value: string, targetSchema: ZodTypeAny) {
+    if (!targetSchema) return value;
+
+    if (
+      targetSchema instanceof ZodString ||
+      targetSchema instanceof ZodEnum ||
+      targetSchema instanceof ZodNativeEnum
+    ) {
+      return value;
+    }
+
+    if (targetSchema instanceof ZodNumber) {
+      return Number(value);
+    }
+
+    if (targetSchema instanceof ZodBoolean) {
+      return value.toLowerCase() === 'true';
+    }
+
+    if (targetSchema instanceof ZodBigInt) {
+      return BigInt(value);
+    }
+
+    throw new Error(
+      `Cannot convert String to ${targetSchema.constructor.name}`
+    );
+  }
+
+  private static convertFromBigDecimal(
+    value: BigDecimalNumber,
+    targetSchema: ZodTypeAny
+  ) {
+    if (targetSchema instanceof ZodNumber) {
+      return value.toNumber();
+    }
+
+    if (targetSchema instanceof ZodString) {
+      return value.toString();
+    }
+
+    throw new Error(
+      `Cannot convert Number to ${targetSchema.constructor.name}`
+    );
+  }
+
+  private static convertFromBigInteger(
+    value: BigIntegerNumber,
+    targetSchema: ZodTypeAny
+  ) {
+    if (targetSchema instanceof ZodNumber) {
+      return value.toNumber();
+    }
+
+    if (targetSchema instanceof ZodBigInt) {
+      return BigInt(value.toString());
+    }
+
+    if (targetSchema instanceof ZodString) {
+      return value.toString();
+    }
+
+    throw new Error(
+      `Cannot convert Number to ${targetSchema.constructor.name}`
+    );
+  }
+
+  private static convertFromBoolean(value: boolean, targetSchema: ZodTypeAny) {
+    if (!targetSchema) return value;
+
+    if (targetSchema instanceof ZodBoolean) {
+      return value;
+    }
+
+    if (targetSchema instanceof ZodString) {
+      return value.toString();
+    }
+
+    if (targetSchema instanceof ZodNumber) {
+      return Number(value);
+    }
+
+    if (targetSchema instanceof ZodBigInt) {
+      return BigInt(value);
+    }
+
+    throw new Error(
+      `Cannot convert Boolean to ${targetSchema.constructor.name}`
+    );
+  }
+
+  private static isPrimitive(targetSchema: ZodTypeAny) {
+    if (!targetSchema) return false;
+
+    return (
+      targetSchema instanceof ZodString ||
+      targetSchema instanceof ZodNumber ||
+      targetSchema instanceof ZodBoolean ||
+      targetSchema instanceof ZodBigInt
+    );
+  }
+
+  static getDefaultPrimitiveValue(targetSchema: ZodTypeAny) {
+    if (!targetSchema) return null;
+
+    if (targetSchema instanceof ZodNumber) {
+      return 0;
+    } else if (targetSchema instanceof ZodBoolean) {
+      return false;
+    } else if (targetSchema instanceof ZodString) {
+      return '';
+    }
+
+    throw new Error(
+      `Unsupported primitive type: ${targetSchema.constructor.name}`
+    );
+  }
+}

--- a/libs/language/src/lib/mapping/__tests__/Chess.yaml
+++ b/libs/language/src/lib/mapping/__tests__/Chess.yaml
@@ -1,0 +1,276 @@
+---
+name: Chess
+type:
+  blueId: 6j4rVp2aAm35U7dvbYPQsdi82JUpRPb1kTfkYrhHxvqE
+properties:
+  playerToMove:
+    description: Indicates whose move it is ('white' or 'black')
+  winner:
+    description:
+      "Indicates who won the game (e.g., 'White', 'Black', or 'None' if\
+      \ the game is not over or ended in a draw)"
+    type:
+      blueId: F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP
+  draw:
+    description: Indicates whether the game ended in a draw (true) or not (false)
+    type:
+      blueId: EL6AjrbJsxTWRTPzY8WR8Y2zAMXRbydQj83PcZwuAHbo
+  chessboard:
+    description: Chessboard state in FEN notation
+    type:
+      blueId: F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP
+  movesHistory:
+    description: History of moves made
+    type:
+      blueId: G8wmfjEqugPEEXByMYWJXiEdbLToPRWNQEekNxrxfQWB
+    itemType:
+      blueId: MFGzp8CtRVLb9CF2xAc8kt3jwV99sag7jpdHemZmGz9
+  gameOver:
+    description:
+      Indicates whether the game has ended (true) or is still in progress
+      (false)
+    type:
+      blueId: EL6AjrbJsxTWRTPzY8WR8Y2zAMXRbydQj83PcZwuAHbo
+workflows:
+  items:
+    - steps:
+        items:
+          - type:
+              blueId: DpdjTNXQdgWGxDyB1LLUNFvxSNNM9L9qGMoKZxzYMDoB
+            changeset:
+              items:
+                - val:
+                    type:
+                      blueId: F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP
+                    value: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1
+                  op:
+                    type:
+                      blueId: F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP
+                    value: replace
+                  path:
+                    type:
+                      blueId: F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP
+                    value: /properties/chessboard
+                - val:
+                    type:
+                      blueId: F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP
+                    value: white
+                  op:
+                    type:
+                      blueId: F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP
+                    value: replace
+                  path:
+                    type:
+                      blueId: F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP
+                    value: /properties/playerToMove
+          - type:
+              blueId: 6sdEGwtrVJhdto5CsDzm81YrJtHTZrdsenZkyCWJLniU
+            event:
+              type:
+                blueId: H6u17c2fXJnmshciJVjqxoHVH48YirQYVbFXCTk8ZSym
+              playerBlackTimeline:
+                blueId: "${contract('/messaging/participants/Player Black/timeline/blueId')}"
+              playerWhiteTimeline:
+                blueId: "${contract('/messaging/participants/Player White/timeline/blueId')}"
+      trigger:
+        name: TriggerStep
+        event:
+          type:
+            blueId: 3uzSCGkrdX4hTFGuLbyZES7NQmiuFskCpUy572GxNQuC
+    - name: Move
+      steps:
+        items:
+          - name: Check Player
+            type:
+              blueId: CFKAD5Up8XpNyPHwRBEwiwSUdfFUoGqVVsW29k6te88p
+            code:
+              type:
+                blueId: F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP
+              value:
+                "let playerToMove = contract(\"/properties/playerToMove\");\nlet\
+                \ expectedTimeline = (playerToMove === 'white') ? \n    contract(\"/messaging/participants/Player\
+                \ White/timeline\") :\n    contract(\"/messaging/participants/Player Black/timeline\"\
+                )\nlet timeline = event.timeline;\n\nif (timeline.blueId != expectedTimeline.blueId)\
+                \ {                   \n  throw new RejectAndAwaitNextEventException('Not\
+                \ your move!');\n}\nreturn { }\n"
+          - name: ProcessMove
+            type:
+              blueId: CFKAD5Up8XpNyPHwRBEwiwSUdfFUoGqVVsW29k6te88p
+            code:
+              type:
+                blueId: F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP
+              value: |
+                const chessModule = importBlueESModule('blue:9uGqgr62FtodKDH1KqGb1syeqHfSRo7ySQ5KY8bTutNu');
+                const Chess = chessModule.Chess;
+
+                function checkMove(from, to, position) {
+                    const game = new Chess(position);
+
+                    try {
+                        const move = game.move({ from, to });
+                        if (move === null) {
+                            return { legal: false, position: game.fen(), gameOver: false, winner: null, draw: false };
+                        }
+                        const newPosition = game.fen();
+
+                        let gameOver = game.isGameOver();
+                        let winner = null;
+                        let draw = false;
+
+                        if (gameOver) {
+                            if (game.isCheckmate()) {
+                                winner = game.turn() === 'w' ? 'black' : 'white';
+                            } else if (game.isDraw()) {
+                                draw = true;
+                            }
+                        }
+
+                        return { legal: true, position: newPosition, gameOver: gameOver, winner: winner, draw: draw };
+                    } catch (error) {
+                        return { legal: false, position: game.fen(), error: error.message, gameOver: false, winner: null, draw: false };
+                    }
+                }
+
+                let position = contract("/properties/chessboard");
+                let from = event.message.from;
+                let to = event.message.to;
+                let result;
+
+                result = checkMove(from, to, position);
+
+                if (!result.legal) {
+                  throw new RejectAndAwaitNextEventException('Illegal move');
+                }
+
+                if (result.winner === null) {
+                  result.winner = 'None';
+                }
+
+                return { result };
+          - name: Emit Event
+            type:
+              blueId: 6sdEGwtrVJhdto5CsDzm81YrJtHTZrdsenZkyCWJLniU
+            event:
+              type:
+                blueId: EkEtUob9ZEKzd61Fk8u1KFDZVZAhCLmzxcvTLvYgp3iw
+              playerMakingMove:
+                type:
+                  blueId: F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP
+                value: '${contract("/properties/playerToMove")}'
+              winner:
+                type:
+                  blueId: F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP
+                value: '${steps.ProcessMove.result.winner}'
+              chessboardAfterMove:
+                type:
+                  blueId: F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP
+                value: '${steps.ProcessMove.result.position}'
+              from:
+                type:
+                  blueId: F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP
+                value: '${event.message.from}'
+              draw:
+                type:
+                  blueId: F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP
+                value: '${steps.ProcessMove.result.draw}'
+              to:
+                type:
+                  blueId: F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP
+                value: '${event.message.to}'
+              gameOver:
+                type:
+                  blueId: F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP
+                value: '${steps.ProcessMove.result.gameOver}'
+          - name: Apply Changes
+            type:
+              blueId: DpdjTNXQdgWGxDyB1LLUNFvxSNNM9L9qGMoKZxzYMDoB
+            changeset:
+              items:
+                - val:
+                    type:
+                      blueId: F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP
+                    value: '${steps.ProcessMove.result.position}'
+                  op:
+                    type:
+                      blueId: F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP
+                    value: replace
+                  path:
+                    type:
+                      blueId: F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP
+                    value: /properties/chessboard
+                - val:
+                    type:
+                      blueId: F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP
+                    value: '${steps.ProcessMove.result.draw}'
+                  op:
+                    type:
+                      blueId: F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP
+                    value: replace
+                  path:
+                    type:
+                      blueId: F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP
+                    value: /properties/draw
+                - val:
+                    type:
+                      blueId: F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP
+                    value: '${steps.ProcessMove.result.winner}'
+                  op:
+                    type:
+                      blueId: F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP
+                    value: replace
+                  path:
+                    type:
+                      blueId: F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP
+                    value: /properties/winner
+                - val:
+                    type:
+                      blueId: F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP
+                    value: '${steps.ProcessMove.result.gameOver}'
+                  op:
+                    type:
+                      blueId: F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP
+                    value: replace
+                  path:
+                    type:
+                      blueId: F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP
+                    value: /properties/gameOver
+                - val:
+                    type:
+                      blueId: F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP
+                    value:
+                      "${(contract(\"/properties/playerToMove\") === \"white\") ? \"\
+                      black\" : \"white\"}"
+                  op:
+                    type:
+                      blueId: F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP
+                    value: replace
+                  path:
+                    type:
+                      blueId: F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP
+                    value: /properties/playerToMove
+                - val:
+                    type:
+                      blueId: F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP
+                    value: '${event.message}'
+                  op:
+                    type:
+                      blueId: F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP
+                    value: add
+                  path:
+                    type:
+                      blueId: F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP
+                    value: /properties/movesHistory/-
+      trigger:
+        name: TriggerStep
+        event:
+          type:
+            blueId: 5BDj3UbH6nUPh6bUQ9vfEchjV2vGLMwhd1FJ5UYaRcos
+          message:
+            type:
+              blueId: MFGzp8CtRVLb9CF2xAc8kt3jwV99sag7jpdHemZmGz9
+messaging:
+  participants:
+    Player White:
+      description: Player White timeline
+    Player Black:
+      description: Player Black timeline

--- a/libs/language/src/lib/mapping/__tests__/NodeToObjectConverter.test.ts
+++ b/libs/language/src/lib/mapping/__tests__/NodeToObjectConverter.test.ts
@@ -1,0 +1,1203 @@
+import z from 'zod';
+import { BigIntegerNumber, NodeDeserializer } from '../../model';
+import { JsonBlueValue } from '../../../schema/jsonBlue';
+import { yamlBlueParse } from '../../../utils/yamlBlue';
+import {
+  INTEGER_TYPE_BLUE_ID,
+  LIST_TYPE_BLUE_ID,
+  TEXT_TYPE_BLUE_ID,
+} from '../../utils/Properties';
+import { BlueIdCalculator, Properties } from '../../utils';
+import { schemas, TestEnum } from './schema';
+import { TypeSchemaResolver } from '../../utils/TypeSchemaResolver';
+import { NodeToObjectConverter } from '../NodeToObjectConverter';
+import { getBlueObjectValue } from '../../../utils/blueObject/getters';
+import { BlueObject, isBlueObject } from '../../../schema';
+import {
+  JavaScriptCodeStepSchema,
+  TriggerEventStepSchema,
+  UpdateStepSchema,
+} from './schema/contract';
+
+const {
+  ContractSchema,
+  ChessContractSchema,
+  doctorSchema,
+  nurseSchema,
+  personSchema,
+  personDictionaryExampleSchema,
+  personListExampleSchema,
+  personObjectExampleSchema,
+  personValueExampleSchema,
+  xSchema,
+  y1Schema,
+  x1Schema,
+  x2Schema,
+  x3Schema,
+  x11Schema,
+  x12Schema,
+} = schemas;
+
+describe('blueNodeToObject', () => {
+  let converter: NodeToObjectConverter;
+
+  beforeEach(() => {
+    const resolver = new TypeSchemaResolver(Object.values(schemas));
+    converter = new NodeToObjectConverter(resolver);
+  });
+
+  it('should convert a string value to a string', () => {
+    const node = NodeDeserializer.deserialize(
+      yamlBlueParse('Hello') as JsonBlueValue
+    );
+
+    const result = converter.convert(node, z.string());
+    expect(result).toBe('Hello');
+  });
+
+  it('should convert a blue node to an object of type Person', () => {
+    const yaml =
+      'type:\n' +
+      '  blueId: AnnotatedPerson-BlueId\n' +
+      'name: John Doe\n' +
+      'surname: Doe\n' +
+      'age: 30\n' +
+      'personalInfo:\n' +
+      '  name: John Doe\n' +
+      '  description: A software engineer\n' +
+      'hobbies:\n' +
+      '  - name: Reading\n' +
+      '    description: Reading books\n' +
+      '    duration: 30';
+
+    const node = NodeDeserializer.deserialize(
+      yamlBlueParse(yaml) as JsonBlueValue
+    );
+
+    const hobbySchema = z.object({
+      name: z.string(),
+      description: z.string().optional(),
+      duration: z.number().optional(),
+    });
+
+    const hobbiesSchema = z.array(hobbySchema);
+
+    const personSchema = z.object({
+      age: z.number(),
+      name: z.string(),
+      surname: z.string(),
+      personalInfo: z.object({
+        name: z.string(),
+        description: z.string(),
+      }),
+      hobbies: hobbiesSchema,
+    });
+
+    const result = converter.convert(node, personSchema);
+
+    expect(result).toMatchInlineSnapshot(`
+        {
+          "age": 30,
+          "hobbies": [
+            {
+              "description": "Reading books",
+              "duration": 30,
+              "name": "Reading",
+            },
+          ],
+          "name": "John Doe",
+          "personalInfo": {
+            "description": "A software engineer",
+            "name": "John Doe",
+          },
+          "surname": "Doe",
+        }
+      `);
+  });
+
+  it('should handle lazy properties correctly', () => {
+    const yaml = `
+      name: Main Category
+      rating: 10
+      subcategories:
+        - name: Subcategory 1
+          rating: 9
+        - name: Subcategory 2
+          rating: 1
+    `;
+
+    const node = NodeDeserializer.deserialize(
+      yamlBlueParse(yaml) as JsonBlueValue
+    );
+
+    const baseCategorySchema = z.object({
+      name: z.string(),
+      rating: z.number().optional(),
+    });
+
+    type Category = z.infer<typeof baseCategorySchema> & {
+      subcategories?: Category[];
+    };
+
+    const categorySchema: z.ZodType<Category> = baseCategorySchema.extend({
+      subcategories: z.lazy(() => categorySchema.array()).optional(),
+    });
+
+    const result = converter.convert(node, categorySchema);
+
+    expect(result).toMatchInlineSnapshot(`
+          {
+            "name": "Main Category",
+            "rating": 10,
+            "subcategories": [
+              {
+                "name": "Subcategory 1",
+                "rating": 9,
+              },
+              {
+                "name": "Subcategory 2",
+                "rating": 1,
+              },
+            ],
+          }
+        `);
+  });
+
+  describe('additional tests', () => {
+    it('should convert X with primitive fields - testXConversion', () => {
+      const xYaml = `
+      type:
+        blueId: X-BlueId
+      byteField: 127
+      byteObjectField: -128
+      shortField: 32767
+      shortObjectField: -32768
+      intField: 2147483647
+      integerField: -2147483648
+      longField: 9007199254740991
+      longObjectField: -9007199254740991
+      floatField: 3.14
+      floatObjectField: -3.14
+      doubleField: 3.141592653589793
+      doubleObjectField: -3.141592653589793
+      booleanField: true
+      booleanObjectField: false
+      charField: A
+      characterField: Z
+      stringField: Hello, World!
+      bigIntegerField:
+        type:
+          blueId: ${Properties.INTEGER_TYPE_BLUE_ID}
+        value: "123456789012345678901234567890"
+      bigDecimalField:
+        type:
+          blueId: ${Properties.DOUBLE_TYPE_BLUE_ID}
+        value: "3.14159265358979323846"
+      enumField: SOME_ENUM_VALUE`;
+
+      const node = NodeDeserializer.deserialize(
+        yamlBlueParse(xYaml) as JsonBlueValue
+      );
+
+      const x = converter.convert(node, xSchema);
+
+      expect(x).toBeDefined();
+      expect(x.byteField).toBe(127);
+      expect(x.byteObjectField).toBe(-128);
+      expect(x.shortField).toBe(32767);
+      expect(x.shortObjectField).toBe(-32768);
+      expect(x.intField).toBe(2147483647);
+      expect(x.integerField).toBe(-2147483648);
+      expect(x.longField).toBe(9007199254740991); // Max safe integer in JS
+      expect(x.longObjectField).toBe(-9007199254740991);
+      expect(x.floatField).toBeCloseTo(3.14, 2);
+      expect(x.floatObjectField).toBeCloseTo(-3.14, 2);
+      expect(x.doubleField).toBeCloseTo(3.141592653589793, 15);
+      expect(x.doubleObjectField).toBeCloseTo(-3.141592653589793, 15);
+      expect(x.booleanField).toBe(true);
+      expect(x.booleanObjectField).toBe(false);
+      expect(x.charField).toBe('A');
+      expect(x.characterField).toBe('Z');
+      expect(x.stringField).toBe('Hello, World!');
+      // expect(x.bigIntegerField).toBe('123456789012345678901234567890');
+      // expect(x.bigDecimalField).toBe('3.14159265358979323846');
+      expect(x.enumField).toBe(TestEnum.SOME_ENUM_VALUE);
+    });
+
+    it('should convert X1 with collections - testX1Conversion', () => {
+      const x1Yaml = `
+        type:
+          blueId: X1-BlueId
+        name: X1 Instance
+        intField: 42
+        stringField: X1 String
+        intArrayField:
+          type:
+            blueId: ${LIST_TYPE_BLUE_ID}
+          itemType:
+            blueId: ${INTEGER_TYPE_BLUE_ID}
+          items: [1, 2, 3, 4, 5]
+        stringListField:
+          type:
+            blueId: ${LIST_TYPE_BLUE_ID}
+          itemType:
+            blueId: ${TEXT_TYPE_BLUE_ID}
+          items:
+            - apple
+            - banana
+            - cherry
+        integerSetField:
+          type:
+            blueId: ${LIST_TYPE_BLUE_ID}
+          itemType:
+            blueId: ${INTEGER_TYPE_BLUE_ID}
+          items: [10, 20, 30, 40, 50]
+`;
+
+      const jsonValue = yamlBlueParse(x1Yaml) as JsonBlueValue;
+      const node = NodeDeserializer.deserialize(jsonValue);
+
+      const x1 = converter.convert(node, x1Schema);
+
+      expect(x1).toBeDefined();
+      expect(x1.intField).toBe(42);
+      expect(x1.stringField).toBe('X1 String');
+      expect(x1.intArrayField).toEqual([1, 2, 3, 4, 5]);
+      expect(x1.stringListField).toEqual(['apple', 'banana', 'cherry']);
+      expect(x1.integerSetField).toBeInstanceOf(Set);
+      expect(Array.from(x1.integerSetField ?? new Set())).toEqual([
+        10, 20, 30, 40, 50,
+      ]);
+    });
+
+    it('should convert X2 with map fields - testX2Conversion', () => {
+      const x2Yaml = `
+        name: X2 Instance
+        type:
+          blueId: X2-BlueId
+        doubleField: 3.14159
+        booleanField: true
+        stringIntMapField:
+          key1: 100
+          key2: 200
+          key3: 300`;
+
+      const node = NodeDeserializer.deserialize(
+        yamlBlueParse(x2Yaml) as JsonBlueValue
+      );
+      const x2 = converter.convert(node, x2Schema);
+
+      expect(x2).toBeDefined();
+      expect(x2.doubleField).toBeCloseTo(3.14159, 5);
+      expect(x2.booleanField).toBe(true);
+      expect(x2.stringIntMapField).toBeInstanceOf(Map);
+      expect(x2.stringIntMapField).toEqual(
+        new Map([
+          ['key1', 100],
+          ['key2', 200],
+          ['key3', 300],
+        ])
+      );
+    });
+
+    /**
+     * We don't have concurrent fields in TypeScript, so we cannot recreate this test fully from the JAVA version.
+     */
+    it('should convert X3 with concurrent fields - testX3Conversion', () => {
+      const x3Yaml = `
+        name: X3 Instance
+        type:
+          blueId: X3-BlueId
+        longField: 1234567890
+        atomicIntegerField: 42
+        atomicLongField: 9876543210
+        concurrentMapField:
+          key1: 111
+          key2: 222
+          key3: 333`;
+
+      const node = NodeDeserializer.deserialize(
+        yamlBlueParse(x3Yaml) as JsonBlueValue
+      );
+      const x3 = converter.convert(node, x3Schema);
+
+      expect(x3).toBeDefined();
+      expect(x3.longField).toBe(1234567890);
+      expect(x3.atomicIntegerField).toBe(42);
+      expect(x3.atomicLongField).toBe(9876543210);
+      expect(x3.concurrentMapField?.size).toBe(3);
+      expect(x3.concurrentMapField?.get('key1')).toBe(111);
+      expect(x3.concurrentMapField?.get('key2')).toBe(222);
+      expect(x3.concurrentMapField?.get('key3')).toBe(333);
+    });
+
+    it('should convert X11 with nested collections - testX11Conversion', () => {
+      const x11Yaml = `
+        name: X11 Instance
+        type:
+          blueId: X11-BlueId
+        intField: 11
+        stringField: X11 String
+        intArrayField: [11, 22, 33]
+        stringListField: [red, green, blue]
+        integerSetField: [111, 222, 333]
+        nestedListField:
+          - [a, b, c]
+          - [d, e, f]
+        complexMapField:
+          key1: [1, 2, 3]
+          key2: [4, 5, 6]`;
+
+      const node = NodeDeserializer.deserialize(
+        yamlBlueParse(x11Yaml) as JsonBlueValue
+      );
+      const x11 = converter.convert(node, x11Schema);
+
+      expect(x11).toBeDefined();
+      expect(x11.intField).toBe(11);
+      expect(x11.stringField).toBe('X11 String');
+      expect(x11.intArrayField).toEqual([11, 22, 33]);
+      expect(x11.stringListField).toEqual(['red', 'green', 'blue']);
+      expect(Array.from(x11.integerSetField ?? new Set())).toEqual([
+        111, 222, 333,
+      ]);
+
+      expect(x11.nestedListField?.length).toBe(2);
+      expect(x11.nestedListField?.[0]).toEqual(['a', 'b', 'c']);
+      expect(x11.nestedListField?.[1]).toEqual(['d', 'e', 'f']);
+
+      expect(x11.complexMapField?.size).toBe(2);
+      expect(x11.complexMapField?.get('key1')).toEqual([1, 2, 3]);
+      expect(x11.complexMapField?.get('key2')).toEqual([4, 5, 6]);
+    });
+
+    /**
+     * We don't have queue and deque in TypeScript, so we cannot recreate this test fully from the JAVA version.
+     */
+    it('should convert X12 with queue and deque - testX12Conversion', () => {
+      const x12Yaml = `
+        name: X Variations
+        type:
+          blueId: X12-BlueId
+        byteField: 100
+        integerField: 1000
+        stringField: Base X field
+        intArrayField: [1, 2, 3, 4, 5]
+        stringListField: [apple, banana, cherry]
+        integerSetField: [10, 20, 30, 40, 50]
+        stringQueueField: [first, second, third]
+        integerDequeField: [1000, 2000, 3000]`;
+
+      const node = NodeDeserializer.deserialize(
+        yamlBlueParse(x12Yaml) as JsonBlueValue
+      );
+      const x12 = converter.convert(node, x12Schema);
+
+      expect(x12).toBeDefined();
+      expect(x12.byteField).toBe(100);
+      expect(x12.integerField).toBe(1000);
+      expect(x12.stringField).toBe('Base X field');
+      expect(x12.intArrayField).toEqual([1, 2, 3, 4, 5]);
+      expect(x12.stringListField).toEqual(['apple', 'banana', 'cherry']);
+      expect(Array.from(x12.integerSetField ?? new Set())).toEqual([
+        10, 20, 30, 40, 50,
+      ]);
+
+      expect(x12.stringQueueField).toEqual(['first', 'second', 'third']);
+      expect(x12.integerDequeField).toEqual([1000, 2000, 3000]);
+    });
+
+    it('should convert Y with nested objects and collections - testYConversion', () => {
+      const yYaml = `
+        name: Y Instance
+        type:
+          blueId: Y-BlueId
+        xField:
+          type:
+            blueId: X-BlueId
+          intField: 100
+          stringField: X in Y
+        x1Field:
+          type:
+            blueId: X1-BlueId
+          intArrayField: [1, 2, 3]
+          stringListField: [a, b, c]
+        x2Field:
+          type:
+            blueId: X2-BlueId
+          stringIntMapField:
+            key1: 10
+            key2: 20
+        xListField:
+          - type:
+              blueId: X-BlueId
+            intField: 1
+          - type:
+              blueId: X-BlueId
+            intField: 2
+        xMapField:
+          key1:
+            type:
+              blueId: X-BlueId
+            intField: 10
+          key2:
+            type:
+              blueId: X-BlueId
+            intField: 20
+        x1SetField:
+          - type:
+              blueId: X1-BlueId
+            intArrayField: [4, 5, 6]
+          - type:
+              blueId: X1-BlueId
+            intArrayField: [7, 8, 9]
+        x2MapField:
+          mapKey1:
+            type:
+              blueId: X2-BlueId
+            stringIntMapField:
+              innerKey1: 30
+              innerKey2: 40
+          mapKey2:
+            type:
+              blueId: X2-BlueId
+            stringIntMapField:
+              innerKey3: 50
+              innerKey4: 60
+        xArrayField:
+          - type:
+              blueId: X-BlueId
+            intField: 100
+          - type:
+              blueId: X-BlueId
+            intField: 200
+        wildcardXListField:
+          - type:
+              blueId: X1-BlueId
+            intArrayField: [10, 11, 12]
+          - type:
+              blueId: X2-BlueId
+            stringIntMapField:
+              wildcardKey: 70`;
+
+      const node = NodeDeserializer.deserialize(
+        yamlBlueParse(yYaml) as JsonBlueValue
+      );
+
+      const y = converter.convert(node, y1Schema);
+
+      // Basic validation
+      expect(y).toBeDefined();
+
+      // xField validation
+      expect(y.xField).toBeDefined();
+      expect(y.xField?.intField).toBe(100);
+      expect(y.xField?.stringField).toBe('X in Y');
+
+      // x1Field validation
+      expect(y.x1Field).toBeDefined();
+      expect(y.x1Field?.intArrayField).toEqual([1, 2, 3]);
+      expect(y.x1Field?.stringListField).toEqual(['a', 'b', 'c']);
+
+      // x2Field validation
+      expect(y.x2Field).toBeDefined();
+      expect(y.x2Field?.stringIntMapField?.get('key1')).toBe(10);
+      expect(y.x2Field?.stringIntMapField?.get('key2')).toBe(20);
+
+      // xListField validation
+      expect(y.xListField).toBeDefined();
+      expect(y.xListField?.length).toBe(2);
+      expect(y.xListField?.[0].intField).toBe(1);
+      expect(y.xListField?.[1].intField).toBe(2);
+
+      // xMapField validation
+      expect(y.xMapField).toBeDefined();
+      expect(y.xMapField?.size).toBe(2);
+      expect(y.xMapField?.get('key1')?.intField).toBe(10);
+      expect(y.xMapField?.get('key2')?.intField).toBe(20);
+
+      // x1SetField validation
+      expect(y.x1SetField).toBeDefined();
+      expect(y.x1SetField?.size).toBe(2);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const x1SetArray = Array.from(y.x1SetField!);
+      expect(
+        x1SetArray.some(
+          (x1) => JSON.stringify(x1.intArrayField) === JSON.stringify([4, 5, 6])
+        )
+      ).toBe(true);
+      expect(
+        x1SetArray.some(
+          (x1) => JSON.stringify(x1.intArrayField) === JSON.stringify([7, 8, 9])
+        )
+      ).toBe(true);
+
+      // x2MapField validation
+      expect(y.x2MapField).toBeDefined();
+      expect(y.x2MapField?.size).toBe(2);
+      expect(
+        y.x2MapField?.get('mapKey1')?.stringIntMapField?.get('innerKey1')
+      ).toBe(30);
+      expect(
+        y.x2MapField?.get('mapKey1')?.stringIntMapField?.get('innerKey2')
+      ).toBe(40);
+      expect(
+        y.x2MapField?.get('mapKey2')?.stringIntMapField?.get('innerKey3')
+      ).toBe(50);
+      expect(
+        y.x2MapField?.get('mapKey2')?.stringIntMapField?.get('innerKey4')
+      ).toBe(60);
+
+      // xArrayField validation
+      expect(y.xArrayField).toBeDefined();
+      expect(y.xArrayField?.length).toBe(2);
+      expect(y.xArrayField?.[0].intField).toBe(100);
+      expect(y.xArrayField?.[1].intField).toBe(200);
+
+      // wildcardXListField validation
+      expect(y.wildcardXListField).toBeDefined();
+      expect(y.wildcardXListField?.length).toBe(2);
+
+      const firstWildcard = y.wildcardXListField?.[0];
+      const secondWildcard = y.wildcardXListField?.[1];
+
+      const resultX1 = x1Schema.safeParse(firstWildcard);
+      expect(resultX1.success).toBeTruthy();
+      expect(resultX1.data?.intArrayField).toEqual([10, 11, 12]);
+
+      const resultX2 = x2Schema.safeParse(secondWildcard);
+      expect(resultX2.success).toBeTruthy();
+      expect(resultX2.data?.stringIntMapField?.get('wildcardKey')).toBe(70);
+    });
+
+    it('should convert Y1 with nested objects and collections - testY1Conversion', () => {
+      const y1Yaml = `
+        name: Y1 Instance
+        type:
+          blueId: Y1-BlueId
+        xField:
+          type:
+            blueId: X-BlueId
+          intField: 100
+        x11Field:
+          type:
+            blueId: X11-BlueId
+          nestedListField:
+            - [a, b, c]
+            - [d, e, f]
+        x12Field:
+          type:
+            blueId: X12-BlueId
+          stringQueueField: [first, second, third]
+        x11ListField:
+          - type:
+              blueId: X11-BlueId
+            complexMapField:
+              key1: [1, 2, 3]
+          - type:
+              blueId: X11-BlueId
+            complexMapField:
+              key2: [4, 5, 6]`;
+
+      const node = NodeDeserializer.deserialize(
+        yamlBlueParse(y1Yaml) as JsonBlueValue
+      );
+
+      const result = converter.convert(node, y1Schema);
+
+      expect(result).toBeDefined();
+      expect(result.xField?.intField).toBe(100);
+      expect(result.x11Field?.nestedListField).toHaveLength(2);
+      expect(result.x11Field?.nestedListField?.[0]).toEqual(['a', 'b', 'c']);
+      expect(result.x11Field?.nestedListField?.[1]).toEqual(['d', 'e', 'f']);
+      expect(result.x12Field?.stringQueueField).toEqual([
+        'first',
+        'second',
+        'third',
+      ]);
+      expect(result.x11ListField).toHaveLength(2);
+      expect(result.x11ListField?.[0]?.complexMapField?.get('key1')).toEqual([
+        1, 2, 3,
+      ]);
+      expect(result.x11ListField?.[1]?.complexMapField?.get('key2')).toEqual([
+        4, 5, 6,
+      ]);
+    });
+
+    it('should handle different object variants correctly - testObjectVariants', () => {
+      const personTestDataYaml = `
+        name: Person Testing
+        type:
+          blueId: PersonTestData-BlueId
+        alice1:
+          name: Alice
+          surname: Smith
+          age: 25
+        alice2:
+          name: Alice
+          surname: Smith
+          age: 25
+        alice3:
+          name: Alice
+          surname: Smith
+          age: 25
+        alice4:
+          name: Alice
+          surname: Smith
+          age: 25
+        alice5:
+          type:
+            blueId: Nurse-BlueId
+          name: Alice
+          surname: Smith
+          age: 25
+          yearsOfExperience: 4`;
+
+      const node = NodeDeserializer.deserialize(
+        yamlBlueParse(personTestDataYaml) as JsonBlueValue
+      );
+
+      const result = converter.convert(node, personObjectExampleSchema);
+
+      expect(result).toBeDefined();
+
+      // Test alice1
+      expect(result.alice1).toBeDefined();
+      expect(result.alice1).toBe(
+        BlueIdCalculator.calculateBlueIdSync(result?.alice2)
+      );
+
+      // Test alice2
+      const alice2 = result.alice2;
+      expect(alice2).toBeDefined();
+      expect(alice2?.getName()).toBe('Alice');
+      expect(alice2?.getProperties()?.['surname'].getValue()).toBe('Smith');
+      expect(alice2?.getProperties()?.['age'].getValue()).toEqual(
+        new BigIntegerNumber(25)
+      );
+
+      // Test alice3
+      const alice3 = result.alice3;
+      expect(alice3).toBeDefined();
+      expect(alice3?.name).toBe('Alice');
+      expect(isBlueObject(alice3?.surname)).toBeTruthy();
+      expect(getBlueObjectValue(alice3?.surname as BlueObject)).toBe('Smith');
+      expect(isBlueObject(alice3?.age)).toBeTruthy();
+      expect(getBlueObjectValue(alice3?.age as BlueObject)).toBe(25);
+
+      // Test alice4
+      expect(result.alice4).toBeDefined();
+      expect(result.alice4?.name).toBe('Alice');
+      expect(result.alice4?.surname).toBe('Smith');
+      expect(result.alice4?.age).toBe(25);
+
+      // Test alice5 (Nurse)
+      expect(result.alice5).toBeDefined();
+      const resultNurse = nurseSchema.safeParse(result.alice5);
+      expect(resultNurse.success).toBeTruthy();
+      expect(resultNurse.data?.name).toBe('Alice');
+      expect(resultNurse.data?.surname).toBe('Smith');
+      expect(resultNurse.data?.age).toBe(25);
+      expect(resultNurse.data?.yearsOfExperience).toBe(4);
+    });
+
+    it('should handle different value variants correctly - testValueVariants', () => {
+      const personTestDataYaml = `
+        type:
+          blueId: PersonValue-BlueId
+        age1:
+          type:
+            blueId: DHmxTkFbXePZHCHCYmQr2dSzcNLcryFVjXVHkdQrrZr8
+          name: Official Age
+          description: Description for official age
+          value: 25
+        age2:
+          type:
+            blueId: DHmxTkFbXePZHCHCYmQr2dSzcNLcryFVjXVHkdQrrZr8
+          name: Official Age
+          description: Description for official age
+          value: 25
+        age3:
+          type:
+            blueId: DHmxTkFbXePZHCHCYmQr2dSzcNLcryFVjXVHkdQrrZr8
+          name: Official Age
+          description: Description for official age
+          value: 25`;
+
+      const jsonValue = yamlBlueParse(personTestDataYaml) as JsonBlueValue;
+      const node = NodeDeserializer.deserialize(jsonValue);
+
+      const result = converter.convert(node, personValueExampleSchema);
+
+      // Basic validation
+      expect(result).toBeDefined();
+
+      // Test age1 (direct value)
+      expect(result.age1).toBe(25);
+
+      // Test age2 (value with metadata)
+      expect(result.age2).toBe(25);
+      expect(result.age2Name).toBe('Official Age');
+      expect(result.age2Description).toBe('Description for official age');
+
+      // Test age3 (full value object)
+      expect(result.age3).toBeDefined();
+      expect(result.age3?.getName()).toBe('Official Age');
+      expect(result.age3?.getDescription()).toBe(
+        'Description for official age'
+      );
+      expect(result.age3Name).toBe('Official Age');
+      expect(result.age3?.getType()?.getBlueId()).toBe(
+        'DHmxTkFbXePZHCHCYmQr2dSzcNLcryFVjXVHkdQrrZr8'
+      );
+      expect(result.age3?.getValue()).toEqual(new BigIntegerNumber(25));
+      expect(node.getType()?.getBlueId()).toBe('PersonValue-BlueId');
+    });
+
+    it('should handle different list variants correctly - testListVariants', () => {
+      const personTestDataYaml = `
+        type:
+          blueId: PersonList-BlueId
+        team1:
+          - type:
+              blueId: Doctor-BlueId
+            name: Adam
+            specialization: surgeon
+          - type:
+              blueId: Nurse-BlueId
+            name: Betty
+            yearsOfExperience: 12
+        team2:
+          name: Team2 Name
+          description: Team2 Description
+          items:
+            - type:
+                blueId: Doctor-BlueId
+              name: Adam
+              specialization: surgeon
+            - type:
+                blueId: Nurse-BlueId
+              name: Betty
+              yearsOfExperience: 12
+        team3:
+          - type:
+              blueId: Doctor-BlueId
+            name: Adam
+            specialization: surgeon
+          - type:
+              blueId: Nurse-BlueId
+            name: Betty
+            yearsOfExperience: 12`;
+
+      const node = NodeDeserializer.deserialize(
+        yamlBlueParse(personTestDataYaml) as JsonBlueValue
+      );
+
+      const result = converter.convert(node, personListExampleSchema);
+
+      // Basic validation
+      expect(result).toBeDefined();
+
+      // Test team1
+      expect(result.team1).toBeDefined();
+      expect(result.team1).toHaveLength(2);
+
+      const doctor1 = doctorSchema.safeParse(result.team1[0]);
+      expect(doctor1.success).toBeTruthy();
+      const nurse1 = nurseSchema.safeParse(result.team1[1]);
+      expect(nurse1.success).toBeTruthy();
+
+      expect(doctor1.data?.name).toBe('Adam');
+      expect(doctor1.data?.specialization).toBe('surgeon');
+
+      expect(nurse1.data?.name).toBe('Betty');
+      expect(nurse1.data?.yearsOfExperience).toBe(12);
+
+      // Test team2
+      expect(result.team2Name).toBe('Team2 Name');
+      expect(result.team2Description).toBe('Team2 Description');
+      expect(result.team2).toHaveLength(2);
+
+      const doctor2 = doctorSchema.safeParse(result.team2[0]);
+      expect(doctor2.success).toBeTruthy();
+      const nurse2 = nurseSchema.safeParse(result.team2[1]);
+      expect(nurse2.success).toBeTruthy();
+
+      expect(doctor2.data?.name).toBe('Adam');
+      expect(doctor2.data?.specialization).toBe('surgeon');
+
+      expect(nurse2.data?.name).toBe('Betty');
+      expect(nurse2.data?.yearsOfExperience).toBe(12);
+
+      // Test team3
+      expect(result.team3).toBeDefined();
+      expect(result.team3.getItems()).toHaveLength(2);
+
+      const doctorNode = result.team3.getItems()?.[0];
+      const nurseNode = result.team3.getItems()?.[1];
+
+      expect(doctorNode?.getName()).toBe('Adam');
+      expect(doctorNode?.getType()?.getBlueId()).toBe('Doctor-BlueId');
+      expect(doctorNode?.getProperties()?.['specialization'].getValue()).toBe(
+        'surgeon'
+      );
+
+      expect(nurseNode?.getName()).toBe('Betty');
+      expect(nurseNode?.getType()?.getBlueId()).toBe('Nurse-BlueId');
+      expect(
+        nurseNode?.getProperties()?.['yearsOfExperience'].getValue()
+      ).toEqual(new BigIntegerNumber(12));
+
+      // Test node type
+      expect(node.getType()?.getBlueId()).toBe('PersonList-BlueId');
+    });
+
+    it('should handle different dictionary variants correctly - testDictionaryVariants', () => {
+      const personTestDataYaml = `
+          team1:
+            person1:
+              type:
+                blueId: Doctor-BlueId
+              name: Adam
+              specialization: surgeon
+            person2:
+              type:
+                blueId: Nurse-BlueId
+              name: Betty
+              yearsOfExperience: 12
+          team2:
+            person1:
+              type:
+                blueId: Doctor-BlueId
+              name: Adam
+              specialization: surgeon
+            person2:
+              type:
+                blueId: Nurse-BlueId
+              name: Betty
+              yearsOfExperience: 12
+          team3:
+            1:
+              type:
+                blueId: Doctor-BlueId
+              name: Adam
+              specialization: surgeon
+            2:
+              type:
+                blueId: Nurse-BlueId
+              name: Betty
+              yearsOfExperience: 12`;
+
+      const node = NodeDeserializer.deserialize(
+        yamlBlueParse(personTestDataYaml) as JsonBlueValue
+      );
+
+      const result = converter.convert(node, personDictionaryExampleSchema);
+      expect(() => personDictionaryExampleSchema.parse(result)).not.toThrow();
+      expect(result).toBeDefined();
+
+      // Test team1
+      expect(result.team1).toBeDefined();
+      expect(result.team1.size).toBe(2);
+
+      const doctor1 = doctorSchema.safeParse(result.team1.get('person1'));
+      expect(doctor1.success).toBeTruthy();
+      const nurse1 = nurseSchema.safeParse(result.team1.get('person2'));
+      expect(nurse1.success).toBeTruthy();
+
+      expect(doctor1.data?.name).toBe('Adam');
+      expect(doctor1.data?.specialization).toBe('surgeon');
+      expect(nurse1.data?.name).toBe('Betty');
+      expect(nurse1.data?.yearsOfExperience).toBe(12);
+
+      // Test team2
+      expect(result.team2).toBeDefined();
+      expect(result.team2.size).toBe(2);
+
+      const doctor2 = doctorSchema.safeParse(result.team2.get('person1'));
+      expect(doctor2.success).toBeTruthy();
+      const nurse2 = nurseSchema.safeParse(result.team2.get('person2'));
+      expect(nurse2.success).toBeTruthy();
+
+      expect(doctor2.data?.name).toBe('Adam');
+      expect(doctor2.data?.specialization).toBe('surgeon');
+      expect(nurse2.data?.name).toBe('Betty');
+      expect(nurse2.data?.yearsOfExperience).toBe(12);
+
+      // Test team3
+      expect(result.team3).toBeDefined();
+      expect(result.team3.size).toBe(2);
+
+      const doctor3 = doctorSchema.safeParse(result.team3.get(1));
+      expect(doctor3.success).toBeTruthy();
+      const nurse3 = nurseSchema.safeParse(result.team3.get(2));
+      expect(nurse3.success).toBeTruthy();
+
+      expect(doctor3.data?.name).toBe('Adam');
+      expect(doctor3.data?.specialization).toBe('surgeon');
+      expect(nurse3.data?.name).toBe('Betty');
+      expect(nurse3.data?.yearsOfExperience).toBe(12);
+    });
+
+    it('should convert a simple object correctly - testObjectSimple', () => {
+      const personTestDataYaml = `
+        type:
+          blueId: Nurse-BlueId
+        name: Alice
+        surname: Smith
+        age: 25
+        yearsOfExperience: 4`;
+
+      const node = NodeDeserializer.deserialize(
+        yamlBlueParse(personTestDataYaml) as JsonBlueValue
+      );
+
+      const result = converter.convert(node, personSchema);
+
+      expect(result).toBeDefined();
+
+      const nurseResult = nurseSchema.safeParse(result);
+      expect(nurseResult.success).toBeTruthy();
+
+      const nurse = nurseResult.data;
+      expect(nurse?.name).toBe('Alice');
+      expect(nurse?.surname).toBe('Smith');
+      expect(nurse?.age).toBe(25);
+      expect(nurse?.yearsOfExperience).toBe(4);
+    });
+
+    it('should convert a simple object with extended schema correctly - testObjectSimpleExtended', () => {
+      const personTestDataYaml = `
+        type:
+          blueId: X12-BlueId
+        stringQueueField:
+          - A
+          - B
+          - C`;
+
+      const node = NodeDeserializer.deserialize(
+        yamlBlueParse(personTestDataYaml) as JsonBlueValue
+      );
+      const result = converter.convert(node, xSchema);
+
+      expect(result).toBeDefined();
+      const parsedResult = x12Schema.safeParse(result);
+      expect(parsedResult.success).toBeTruthy();
+      expect(parsedResult.data?.stringQueueField).toHaveLength(3);
+    });
+  });
+
+  describe('Contract schema tests', () => {
+    let converter: NodeToObjectConverter;
+
+    beforeEach(() => {
+      const resolver = new TypeSchemaResolver(Object.values(schemas));
+      converter = new NodeToObjectConverter(resolver);
+    });
+
+    it('should convert a basic Contract', () => {
+      const contractYaml = `
+        type:
+          blueId: Contract-BlueId
+        name: Sample Contract
+        description: A test contract
+        messaging:
+          participants:
+            participant1:
+              name: Alice
+              timeline: timeline-1
+            participant2:
+              name: Bob
+              timeline: timeline-2
+        workflows:
+          - name: Main Workflow
+            description: Primary workflow
+            steps:
+              - name: Step 1
+                description: First step
+                condition:
+                  type:
+                    blueId: Condition-BlueId
+                  value: true
+              - name: Step 2
+                description: Second step
+                condition:
+                  type:
+                    blueId: Condition-BlueId
+                  value: false`;
+
+      const node = NodeDeserializer.deserialize(
+        yamlBlueParse(contractYaml) as JsonBlueValue
+      );
+
+      const result = converter.convert(node, ContractSchema);
+
+      expect(result).toBeDefined();
+      expect(result.name).toBe('Sample Contract');
+      expect(result.description).toBe('A test contract');
+
+      expect(result.messaging?.participants).toBeDefined();
+      expect(result.messaging?.participants?.participant1?.name).toBe('Alice');
+      expect(result.messaging?.participants?.participant1?.timeline).toBe(
+        'timeline-1'
+      );
+      expect(result.messaging?.participants?.participant2?.name).toBe('Bob');
+      expect(result.messaging?.participants?.participant2?.timeline).toBe(
+        'timeline-2'
+      );
+
+      expect(result.workflows).toHaveLength(1);
+      const workflow = result.workflows?.[0];
+      expect(workflow?.name).toBe('Main Workflow');
+      expect(workflow?.description).toBe('Primary workflow');
+
+      expect(workflow?.steps).toHaveLength(2);
+      expect(workflow?.steps?.[0].name).toBe('Step 1');
+      expect(workflow?.steps?.[0].description).toBe('First step');
+      expect(workflow?.steps?.[0].condition).toBeDefined();
+      expect(workflow?.steps?.[1].name).toBe('Step 2');
+      expect(workflow?.steps?.[1].description).toBe('Second step');
+      expect(workflow?.steps?.[1].condition).toBeDefined();
+    });
+
+    it('should convert a ChessContract', () => {
+      const chessContractYaml = `
+        type:
+          blueId: ChessContract-BlueId
+        name: Chess Game Contract
+        description: A contract for managing chess games
+        properties:
+          chessboard: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR
+          winner: white
+          draw: false
+          gameOver: true
+          playerToMove: black
+          assistingContract: contract-123
+          assistingContractWhite: contract-white
+          assistingContractBlack: contract-black
+        messaging:
+          participants:
+            white:
+              name: Player White
+              timeline: timeline-white
+            black:
+              name: Player Black
+              timeline: timeline-black
+        workflows:
+          - name: Game Flow
+            description: Manages the chess game flow
+            steps:
+              - name: Move Validation
+                description: Validates player moves
+                condition:
+                  type:
+                    blueId: MoveValidation-BlueId
+                  value: true`;
+
+      const node = NodeDeserializer.deserialize(
+        yamlBlueParse(chessContractYaml) as JsonBlueValue
+      );
+
+      const result = converter.convert(node, ChessContractSchema);
+
+      expect(result).toBeDefined();
+      expect(result.name).toBe('Chess Game Contract');
+      expect(result.description).toBe('A contract for managing chess games');
+
+      expect(result.properties).toBeDefined();
+      expect(result.properties?.chessboard).toBe(
+        'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR'
+      );
+      expect(result.properties?.winner).toBe('white');
+      expect(result.properties?.draw).toBe(false);
+      expect(result.properties?.gameOver).toBe(true);
+      expect(result.properties?.playerToMove).toBe('black');
+      expect(result.properties?.assistingContract).toBe('contract-123');
+      expect(result.properties?.assistingContractWhite).toBe('contract-white');
+      expect(result.properties?.assistingContractBlack).toBe('contract-black');
+
+      expect(result.messaging?.participants?.white?.name).toBe('Player White');
+      expect(result.messaging?.participants?.white?.timeline).toBe(
+        'timeline-white'
+      );
+      expect(result.messaging?.participants?.black?.name).toBe('Player Black');
+      expect(result.messaging?.participants?.black?.timeline).toBe(
+        'timeline-black'
+      );
+
+      expect(result.workflows).toHaveLength(1);
+      const workflow = result.workflows?.[0];
+      expect(workflow?.name).toBe('Game Flow');
+      expect(workflow?.description).toBe('Manages the chess game flow');
+      expect(workflow?.steps).toHaveLength(1);
+      expect(workflow?.steps?.[0].name).toBe('Move Validation');
+      expect(workflow?.steps?.[0].description).toBe('Validates player moves');
+      expect(workflow?.steps?.[0].condition).toBeDefined();
+    });
+
+    it('should convert a complex ChessContract with workflows', async () => {
+      const chessContractYaml = await import('./Chess.yaml?raw');
+
+      const node = NodeDeserializer.deserialize(
+        yamlBlueParse(chessContractYaml.default) as JsonBlueValue
+      );
+
+      const result = converter.convert(node, ChessContractSchema);
+
+      expect(result).toBeDefined();
+      expect(result.name).toBe('Chess');
+
+      expect(result.messaging?.participants?.['Player White']).toBeDefined();
+      expect(
+        result.messaging?.participants?.['Player White']?.description
+      ).toBe('Player White timeline');
+      expect(result.messaging?.participants?.['Player Black']).toBeDefined();
+
+      expect(result.workflows).toBeDefined();
+      expect(result.workflows?.length).toBeGreaterThanOrEqual(2);
+
+      const initWorkflow = result.workflows?.[0];
+      expect(
+        initWorkflow?.trigger?.getProperties()?.event?.getType()?.getBlueId()
+      ).toBe('3uzSCGkrdX4hTFGuLbyZES7NQmiuFskCpUy572GxNQuC');
+      expect(initWorkflow?.steps?.length).toBe(2);
+
+      const initSteps = initWorkflow?.steps;
+      const firstInitWorkflowStep = initSteps?.[0];
+      const secondInitWorkflowStep = initSteps?.[1];
+
+      const firstInitWorkflowStepParsed = UpdateStepSchema.safeParse(
+        firstInitWorkflowStep
+      ).data;
+      expect(firstInitWorkflowStepParsed?.changeset).toHaveLength(2);
+      const firstChangeSet = firstInitWorkflowStepParsed?.changeset?.[0];
+      expect(firstChangeSet?.val?.getValue()).toBe(
+        'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1'
+      );
+      expect(firstChangeSet?.op).toBe('replace');
+      expect(firstChangeSet?.path).toBe('/properties/chessboard');
+
+      const secondInitWorkflowStepParsed = TriggerEventStepSchema.safeParse(
+        secondInitWorkflowStep
+      ).data;
+      expect(
+        secondInitWorkflowStepParsed?.event
+          ?.getProperties()
+          ?.['playerBlackTimeline'].getBlueId()
+      ).toBe(
+        "${contract('/messaging/participants/Player Black/timeline/blueId')}"
+      );
+
+      const moveWorkflow = result.workflows?.[1];
+      expect(moveWorkflow?.name).toBe('Move');
+      expect(moveWorkflow?.steps?.length).toBeGreaterThanOrEqual(1);
+
+      const checkPlayerStep = moveWorkflow?.steps?.[0];
+      expect(checkPlayerStep?.name).toBe('Check Player');
+      const checkPlayerStepParsed =
+        JavaScriptCodeStepSchema.safeParse(checkPlayerStep);
+      expect(checkPlayerStepParsed.success).toBeTruthy();
+      expect(checkPlayerStepParsed.data?.code).toBeDefined();
+    });
+  });
+});

--- a/libs/language/src/lib/mapping/__tests__/schema/contract.ts
+++ b/libs/language/src/lib/mapping/__tests__/schema/contract.ts
@@ -1,0 +1,81 @@
+import z from 'zod';
+import { blueIdField, blueNodeField, withTypeBlueId } from '../../annotations';
+
+const WorkflowStepSchema = withTypeBlueId('WorkflowStep-BlueId')(
+  z.object({
+    name: z.string().optional(),
+    description: z.string().optional(),
+    condition: blueNodeField().optional(),
+  })
+);
+
+export const TriggerEventStepSchema = withTypeBlueId(
+  '6sdEGwtrVJhdto5CsDzm81YrJtHTZrdsenZkyCWJLniU'
+)(
+  WorkflowStepSchema.extend({
+    event: blueNodeField().optional(),
+  })
+);
+
+export const UpdateStepSchema = withTypeBlueId(
+  'DpdjTNXQdgWGxDyB1LLUNFvxSNNM9L9qGMoKZxzYMDoB'
+)(
+  WorkflowStepSchema.extend({
+    changeset: z
+      .array(
+        z.object({
+          op: z.enum(['replace', 'add', 'remove']).optional(),
+          path: z.string().optional(),
+          val: blueNodeField().optional(),
+        })
+      )
+      .optional(),
+  })
+);
+
+export const JavaScriptCodeStepSchema = withTypeBlueId(
+  'CFKAD5Up8XpNyPHwRBEwiwSUdfFUoGqVVsW29k6te88p'
+)(
+  WorkflowStepSchema.extend({
+    code: z.string().optional(),
+  })
+);
+
+const WorkflowSchema = z.object({
+  name: z.string().optional(),
+  description: z.string().optional(),
+  trigger: blueNodeField().optional(),
+  steps: z.array(WorkflowStepSchema).optional(),
+});
+
+const ParticipantSchema = z.object({
+  name: z.string().optional(),
+  description: z.string().optional(),
+  timeline: blueIdField('timeline').optional(),
+});
+
+const MessagingSchema = z.object({
+  participants: z.record(ParticipantSchema).optional(),
+});
+
+export const ContractSchema = z.object({
+  name: z.string().optional(),
+  description: z.string().optional(),
+  messaging: MessagingSchema.optional(),
+  workflows: z.array(WorkflowSchema).optional(),
+});
+
+export const ChessProperties = z.object({
+  chessboard: z.string().optional(),
+  winner: z.string().optional(),
+  draw: z.boolean().optional(),
+  gameOver: z.boolean().optional(),
+  playerToMove: z.string().optional(),
+  assistingContract: z.string().optional(),
+  assistingContractWhite: z.string().optional(),
+  assistingContractBlack: z.string().optional(),
+});
+
+export const ChessContractSchema = ContractSchema.extend({
+  properties: ChessProperties.optional(),
+});

--- a/libs/language/src/lib/mapping/__tests__/schema/doctor.ts
+++ b/libs/language/src/lib/mapping/__tests__/schema/doctor.ts
@@ -1,0 +1,9 @@
+import z from 'zod';
+import { withTypeBlueId } from '../../annotations';
+import { personSchema } from './person';
+
+export const doctorSchema = withTypeBlueId('Doctor-BlueId')(
+  personSchema.extend({
+    specialization: z.string(),
+  })
+);

--- a/libs/language/src/lib/mapping/__tests__/schema/index.ts
+++ b/libs/language/src/lib/mapping/__tests__/schema/index.ts
@@ -1,0 +1,46 @@
+import {
+  ContractSchema,
+  ChessContractSchema,
+  UpdateStepSchema,
+  TriggerEventStepSchema,
+  JavaScriptCodeStepSchema,
+} from './contract';
+import { doctorSchema } from './doctor';
+import { nurseSchema } from './nurse';
+import { personSchema } from './person';
+import { personDictionaryExampleSchema } from './personDictionaryExample';
+import { personListExampleSchema } from './personListExample';
+import { personObjectExampleSchema } from './personObjectExample';
+import { personValueExampleSchema } from './personValueExample';
+import { xSchema } from './x';
+import { x1Schema } from './x1';
+import { x2Schema } from './x2';
+import { x3Schema } from './x3';
+import { x11Schema } from './x11';
+import { x12Schema } from './x12';
+import { y1Schema } from './y1';
+import { ySchema } from './y';
+
+export const schemas = {
+  ContractSchema,
+  ChessContractSchema,
+  UpdateStepSchema,
+  TriggerEventStepSchema,
+  JavaScriptCodeStepSchema,
+  doctorSchema,
+  nurseSchema,
+  personSchema,
+  personDictionaryExampleSchema,
+  personListExampleSchema,
+  personObjectExampleSchema,
+  personValueExampleSchema,
+  xSchema,
+  x1Schema,
+  x2Schema,
+  x3Schema,
+  x11Schema,
+  x12Schema,
+  ySchema,
+  y1Schema,
+};
+export { TestEnum } from './x';

--- a/libs/language/src/lib/mapping/__tests__/schema/nurse.ts
+++ b/libs/language/src/lib/mapping/__tests__/schema/nurse.ts
@@ -1,0 +1,9 @@
+import z from 'zod';
+import { withTypeBlueId } from '../../annotations';
+import { personSchema } from './person';
+
+export const nurseSchema = withTypeBlueId('Nurse-BlueId')(
+  personSchema.extend({
+    yearsOfExperience: z.number().optional(),
+  })
+);

--- a/libs/language/src/lib/mapping/__tests__/schema/person.ts
+++ b/libs/language/src/lib/mapping/__tests__/schema/person.ts
@@ -1,0 +1,10 @@
+import z from 'zod';
+import { withTypeBlueId } from '../../annotations';
+
+export const personSchema = withTypeBlueId('Person-BlueId')(
+  z.object({
+    name: z.string(),
+    surname: z.string().optional(),
+    age: z.number().optional(),
+  })
+);

--- a/libs/language/src/lib/mapping/__tests__/schema/personDictionaryExample.ts
+++ b/libs/language/src/lib/mapping/__tests__/schema/personDictionaryExample.ts
@@ -1,0 +1,13 @@
+import z from 'zod';
+import { withTypeBlueId } from '../../annotations';
+import { personSchema } from './person';
+
+export const personDictionaryExampleSchema = withTypeBlueId(
+  'PersonDictionary-BlueId'
+)(
+  z.object({
+    team1: z.map(z.string(), personSchema),
+    team2: z.map(z.string(), personSchema),
+    team3: z.map(z.number(), personSchema),
+  })
+);

--- a/libs/language/src/lib/mapping/__tests__/schema/personListExample.ts
+++ b/libs/language/src/lib/mapping/__tests__/schema/personListExample.ts
@@ -1,0 +1,18 @@
+import z from 'zod';
+import {
+  blueDescriptionField,
+  blueNameField,
+  blueNodeField,
+  withTypeBlueId,
+} from '../../annotations';
+import { personSchema } from './person';
+
+export const personListExampleSchema = withTypeBlueId('PersonList-BlueId')(
+  z.object({
+    team1: z.array(personSchema),
+    team2Name: blueNameField('team2'),
+    team2Description: blueDescriptionField('team2'),
+    team2: z.array(personSchema),
+    team3: blueNodeField(),
+  })
+);

--- a/libs/language/src/lib/mapping/__tests__/schema/personObjectExample.ts
+++ b/libs/language/src/lib/mapping/__tests__/schema/personObjectExample.ts
@@ -1,0 +1,15 @@
+import z from 'zod';
+import { blueIdField, blueNodeField, withTypeBlueId } from '../../annotations';
+import { personSchema } from './person';
+
+export const personObjectExampleSchema = withTypeBlueId(
+  'PersonObjectExample-BlueId'
+)(
+  z.object({
+    alice1: blueIdField(),
+    alice2: blueNodeField(),
+    alice3: z.record(z.string(), z.unknown()).optional(),
+    alice4: personSchema.optional(),
+    alice5: personSchema.optional(),
+  })
+);

--- a/libs/language/src/lib/mapping/__tests__/schema/personValueExample.ts
+++ b/libs/language/src/lib/mapping/__tests__/schema/personValueExample.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+import {
+  blueDescriptionField,
+  blueNameField,
+  withTypeBlueId,
+  blueNodeField,
+} from '../../annotations';
+
+export const personValueExampleSchema = withTypeBlueId('PersonValue-BlueId')(
+  z.object({
+    age1: z.number().optional(),
+    age2Name: blueNameField('age2'),
+    age2Description: blueDescriptionField('age2'),
+    age2: z.number().optional(),
+    age3Name: blueNameField('age3'),
+    age3: blueNodeField().optional(),
+  })
+);
+
+export type PersonValueExample = z.infer<typeof personValueExampleSchema>;

--- a/libs/language/src/lib/mapping/__tests__/schema/x.ts
+++ b/libs/language/src/lib/mapping/__tests__/schema/x.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+import { withTypeBlueId } from '../../annotations';
+
+export enum TestEnum {
+  SOME_ENUM_VALUE = 'SOME_ENUM_VALUE',
+  ANOTHER_ENUM_VALUE = 'ANOTHER_ENUM_VALUE',
+}
+
+export const xSchema = withTypeBlueId('X-BlueId')(
+  z.object({
+    type: z.string().optional(),
+    // Using number for byte/short/int/long but could add custom validation
+    byteField: z.number().min(-128).max(127).optional(),
+    byteObjectField: z.number().min(-128).max(127).nullable().optional(),
+    shortField: z.number().min(-32768).max(32767).optional(),
+    shortObjectField: z.number().min(-32768).max(32767).nullable().optional(),
+    intField: z.number().int().optional(),
+    integerField: z.number().int().nullable().optional(),
+    longField: z.number().optional(),
+    longObjectField: z.number().nullable().optional(),
+    floatField: z.number().optional(),
+    floatObjectField: z.number().nullable().optional(),
+    doubleField: z.number().optional(),
+    doubleObjectField: z.number().nullable().optional(),
+    booleanField: z.boolean().optional(),
+    booleanObjectField: z.boolean().nullable().optional(),
+    charField: z.string().length(1).optional(),
+    characterField: z.string().length(1).nullable().optional(),
+    stringField: z.string().optional(),
+    // For BigInteger/BigDecimal we'll use string representation
+    // bigIntegerField: z.string().optional(),
+    // bigDecimalField: z.string().optional(),
+    enumField: z.nativeEnum(TestEnum).optional(),
+  })
+);

--- a/libs/language/src/lib/mapping/__tests__/schema/x1.ts
+++ b/libs/language/src/lib/mapping/__tests__/schema/x1.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+import { xSchema } from './x';
+import { withTypeBlueId } from '../../annotations';
+
+export const x1Schema = withTypeBlueId('X1-BlueId')(
+  xSchema.extend({
+    intArrayField: z.array(z.number()).optional(),
+    stringListField: z.array(z.string()).optional(),
+    integerSetField: z.set(z.number()).optional(),
+  })
+);

--- a/libs/language/src/lib/mapping/__tests__/schema/x11.ts
+++ b/libs/language/src/lib/mapping/__tests__/schema/x11.ts
@@ -1,0 +1,10 @@
+import z from 'zod';
+import { x1Schema } from './x1';
+import { withTypeBlueId } from '../../annotations';
+
+export const x11Schema = withTypeBlueId('X11-BlueId')(
+  x1Schema.extend({
+    nestedListField: z.array(z.array(z.string())).optional(),
+    complexMapField: z.map(z.string(), z.array(z.number())).optional(),
+  })
+);

--- a/libs/language/src/lib/mapping/__tests__/schema/x12.ts
+++ b/libs/language/src/lib/mapping/__tests__/schema/x12.ts
@@ -1,0 +1,10 @@
+import z from 'zod';
+import { x1Schema } from './x1';
+import { withTypeBlueId } from '../../annotations';
+
+export const x12Schema = withTypeBlueId('X12-BlueId')(
+  x1Schema.extend({
+    stringQueueField: z.array(z.string()).optional(),
+    integerDequeField: z.array(z.number()).optional(),
+  })
+);

--- a/libs/language/src/lib/mapping/__tests__/schema/x2.ts
+++ b/libs/language/src/lib/mapping/__tests__/schema/x2.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+import { xSchema } from './x';
+import { withTypeBlueId } from '../../annotations';
+
+export const x2Schema = withTypeBlueId('X2-BlueId')(
+  xSchema.extend({
+    stringIntMapField: z.map(z.string(), z.number()).optional(),
+  })
+);

--- a/libs/language/src/lib/mapping/__tests__/schema/x3.ts
+++ b/libs/language/src/lib/mapping/__tests__/schema/x3.ts
@@ -1,0 +1,15 @@
+import z from 'zod';
+import { xSchema } from './x';
+import { withTypeBlueId } from '../../annotations';
+
+/**
+ * In the JAVA version, X3 is a class with concurrent fields.
+ * This is a simplified ZOD version of the same type since these specific implementations don't exist in TypeScript.
+ */
+export const x3Schema = withTypeBlueId('X3-BlueId')(
+  xSchema.extend({
+    atomicIntegerField: z.number().optional(),
+    atomicLongField: z.number().optional(),
+    concurrentMapField: z.map(z.string(), z.number()).optional(),
+  })
+);

--- a/libs/language/src/lib/mapping/__tests__/schema/xSubscription.ts
+++ b/libs/language/src/lib/mapping/__tests__/schema/xSubscription.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const xSubscriptionSchema = z.object({
+  subscriptionId: z.number().optional(),
+});
+
+export type XSubscription = z.infer<typeof xSubscriptionSchema>;

--- a/libs/language/src/lib/mapping/__tests__/schema/y.ts
+++ b/libs/language/src/lib/mapping/__tests__/schema/y.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+import { xSchema } from './x';
+import { x1Schema } from './x1';
+import { x2Schema } from './x2';
+import { xSubscriptionSchema } from './xSubscription';
+import { withTypeBlueId } from '../../annotations';
+
+export const ySchema = withTypeBlueId('Y-BlueId')(
+  z.object({
+    xField: xSchema.optional(),
+    x1Field: x1Schema.optional(),
+    x2Field: x2Schema.optional(),
+
+    xListField: z.array(xSchema).optional(),
+    xMapField: z.map(z.string(), xSchema).optional(),
+    x1SetField: z.set(x1Schema).optional(),
+    x2MapField: z.map(z.string(), x2Schema).optional(),
+    xArrayField: z.array(xSchema).optional(),
+
+    wildcardXListField: z.array(xSchema).optional(),
+    subscriptions: z.array(xSubscriptionSchema).optional(),
+  })
+);

--- a/libs/language/src/lib/mapping/__tests__/schema/y1.ts
+++ b/libs/language/src/lib/mapping/__tests__/schema/y1.ts
@@ -1,0 +1,13 @@
+import z from 'zod';
+import { x11Schema } from './x11';
+import { x12Schema } from './x12';
+import { ySchema } from './y';
+import { withTypeBlueId } from '../../annotations';
+
+export const y1Schema = withTypeBlueId('Y1-BlueId')(
+  ySchema.extend({
+    x11Field: x11Schema.optional(),
+    x12Field: x12Schema.optional(),
+    x11ListField: z.array(x11Schema).optional(),
+  })
+);

--- a/libs/language/src/lib/mapping/__tests__/serializeBlueAnnotated.test.ts
+++ b/libs/language/src/lib/mapping/__tests__/serializeBlueAnnotated.test.ts
@@ -1,0 +1,94 @@
+import { z } from 'zod';
+import { serializeBlueAnnotated } from '../serializeBlueAnnotated';
+import { withTypeBlueId } from '../annotations/typeBlueId';
+import { blueIdField } from '../annotations/blueId';
+import { blueNameField } from '../annotations/blueName';
+import { blueDescriptionField } from '../annotations/blueDescription';
+
+describe('serializeBlueAnnotated Tests', () => {
+  // @TypeBlueId("Example-BlueId")
+  // public class TypeBlueIdExample { public String field; }
+  const TypeBlueIdExampleSchema = withTypeBlueId('Example-BlueId')(
+    z.object({
+      field: z.string().optional(),
+    })
+  );
+
+  it('testTypeBlueIdSerialization', () => {
+    const obj = { field: 'value' };
+    const result = serializeBlueAnnotated(obj, TypeBlueIdExampleSchema);
+
+    const expectedJson = `{"type":{"blueId":"Example-BlueId"},"field":"value"}`;
+    expect(JSON.stringify(result)).toEqual(expectedJson);
+  });
+
+  // @TypeBlueId("BlueId-Example")
+  // public class BlueIdExample { @BlueId public String id; }
+  const BlueIdExampleSchema = withTypeBlueId('BlueId-Example')(
+    z.object({
+      id: blueIdField('id'),
+    })
+  );
+
+  it('testBlueIdSerialization', () => {
+    const obj = { id: '123' };
+    const result = serializeBlueAnnotated(obj, BlueIdExampleSchema);
+
+    const expectedJson = `{"type":{"blueId":"BlueId-Example"},"id":{"blueId":"123"}}`;
+    expect(JSON.stringify(result)).toEqual(expectedJson);
+  });
+
+  // @TypeBlueId("Collection-Example")
+  // public class CollectionExample {
+  //   @BlueName("team") public String teamName;
+  //   @BlueDescription("team") public String teamDescription;
+  //   public List<String> team;
+  // }
+  const CollectionExampleSchema = withTypeBlueId('Collection-Example')(
+    z.object({
+      teamName: blueNameField('team'),
+      teamDescription: blueDescriptionField('team'),
+      team: z.array(z.string()).optional(),
+    })
+  );
+
+  it('testBlueNameAndDescriptionForCollection', () => {
+    const obj = {
+      teamName: 'Dream Team',
+      teamDescription: 'The best team ever',
+      team: ['Alice', 'Bob', 'Charlie'],
+    };
+
+    const result = serializeBlueAnnotated(obj, CollectionExampleSchema);
+
+    const expectedJson = `{"type":{"blueId":"Collection-Example"},"team":{"name":"Dream Team","description":"The best team ever","items":["Alice","Bob","Charlie"]}}`;
+    expect(JSON.stringify(result)).toEqual(expectedJson);
+  });
+
+  // @TypeBlueId("NonCollection-Example")
+  // public class NonCollectionExample {
+  //   @BlueName("field") public String fieldName;
+  //   @BlueDescription("field") public String fieldDescription;
+  //   public String field;
+  // }
+  const NonCollectionExampleSchema = withTypeBlueId('NonCollection-Example')(
+    z.object({
+      fieldName: blueNameField('field'),
+      fieldDescription: blueDescriptionField('field'),
+      field: z.string().optional(),
+    })
+  );
+
+  it('testBlueNameAndDescriptionForNonCollection', () => {
+    const obj = {
+      fieldName: 'Important Field',
+      fieldDescription: 'This field is very important',
+      field: 'Crucial data',
+    };
+
+    const result = serializeBlueAnnotated(obj, NonCollectionExampleSchema);
+
+    const expectedJson = `{"type":{"blueId":"NonCollection-Example"},"field":{"name":"Important Field","description":"This field is very important","value":"Crucial data"}}`;
+    expect(JSON.stringify(result)).toEqual(expectedJson);
+  });
+});

--- a/libs/language/src/lib/mapping/annotations/annotations.ts
+++ b/libs/language/src/lib/mapping/annotations/annotations.ts
@@ -1,0 +1,26 @@
+import { ZodType, ZodTypeAny, ZodTypeDef } from 'zod';
+
+const schemaAnnotations = new WeakMap<ZodTypeAny, Record<string, unknown>>();
+
+/**
+ * A helper to define annotations on a Zod schema.
+ * @param schema Any Zod type
+ * @param annotations   Annotations to define
+ * @returns      The same schema as input
+ */
+export function setAnnotations<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Output = any,
+  Def extends ZodTypeDef = ZodTypeDef,
+  Input = Output,
+  Schema extends ZodType<Output, Def, Input> = ZodType<Output, Def, Input>
+>(schema: Schema, annotations: Record<string, unknown>): Schema {
+  const existing = schemaAnnotations.get(schema) || {};
+  schemaAnnotations.set(schema, { ...existing, ...annotations });
+
+  return schema;
+}
+
+export const getAnnotations = (schema: ZodTypeAny) => {
+  return schemaAnnotations.get(schema);
+};

--- a/libs/language/src/lib/mapping/annotations/blueDescription.ts
+++ b/libs/language/src/lib/mapping/annotations/blueDescription.ts
@@ -1,0 +1,26 @@
+import { isNonNullable } from '@blue-company/shared-utils';
+import { isString } from 'radash';
+import { z, ZodTypeAny } from 'zod';
+import { setAnnotations, getAnnotations } from './annotations';
+
+export const withBlueDescription =
+  (value: string) =>
+  <Schema extends ZodTypeAny = ZodTypeAny>(schema: Schema) => {
+    const annotations = getAnnotations(schema);
+
+    return setAnnotations(schema, {
+      ...annotations,
+      blueDescription: value,
+    });
+  };
+
+export const getBlueDescriptionAnnotation = (schema: ZodTypeAny) => {
+  const annotations = getAnnotations(schema);
+  if (isNonNullable(annotations) && isString(annotations.blueDescription)) {
+    return annotations.blueDescription;
+  }
+  return null;
+};
+
+export const blueDescriptionField = (fieldName: string) =>
+  withBlueDescription(fieldName)(z.string().optional());

--- a/libs/language/src/lib/mapping/annotations/blueId.ts
+++ b/libs/language/src/lib/mapping/annotations/blueId.ts
@@ -1,0 +1,27 @@
+import { z, ZodTypeAny } from 'zod';
+import { getAnnotations, setAnnotations } from './annotations';
+
+const blueIdAnnotation = z.union([z.string(), z.boolean()]);
+
+export const withBlueId =
+  (value: string | boolean) =>
+  <Schema extends ZodTypeAny = ZodTypeAny>(schema: Schema) => {
+    const annotations = getAnnotations(schema);
+
+    return setAnnotations(schema, {
+      ...annotations,
+      blueId: value,
+    });
+  };
+
+export const getBlueIdAnnotation = (schema: ZodTypeAny) => {
+  const annotations = getAnnotations(schema);
+  const result = blueIdAnnotation.safeParse(annotations?.blueId);
+  if (result.success) {
+    return result.data;
+  }
+  return null;
+};
+
+export const blueIdField = (fieldName?: string) =>
+  withBlueId(fieldName ?? true)(z.string());

--- a/libs/language/src/lib/mapping/annotations/blueName.ts
+++ b/libs/language/src/lib/mapping/annotations/blueName.ts
@@ -1,0 +1,28 @@
+import { isNonNullable } from '@blue-company/shared-utils';
+import { isString } from 'radash';
+import { z, ZodTypeAny } from 'zod';
+import { setAnnotations, getAnnotations } from './annotations';
+
+export const withBlueName =
+  (value: string) =>
+  <Schema extends ZodTypeAny = ZodTypeAny>(schema: Schema) => {
+    const annotations = getAnnotations(schema);
+
+    return setAnnotations(schema, {
+      ...annotations,
+      blueName: value,
+    });
+  };
+
+export const getBlueNameAnnotation = (schema: ZodTypeAny) => {
+  const annotations = getAnnotations(schema);
+  if (isNonNullable(annotations) && isString(annotations.blueName)) {
+    return annotations.blueName;
+  }
+  return null;
+};
+
+export const blueNameField = (fieldName: string) => {
+  const blueNameFieldSchema = z.string().optional();
+  return withBlueName(fieldName)(blueNameFieldSchema);
+};

--- a/libs/language/src/lib/mapping/annotations/blueNode.ts
+++ b/libs/language/src/lib/mapping/annotations/blueNode.ts
@@ -1,0 +1,32 @@
+import { isNonNullable } from '@blue-company/shared-utils';
+import { z, ZodTypeAny } from 'zod';
+import { setAnnotations, getAnnotations } from './annotations';
+import { BlueNode } from '../../model/Node';
+
+export const withBlueNode =
+  () =>
+  <Schema extends ZodTypeAny = ZodTypeAny>(schema: Schema) => {
+    const annotations = getAnnotations(schema);
+
+    return setAnnotations(schema, {
+      ...annotations,
+      blueNode: true,
+    });
+  };
+
+export const getBlueNodeAnnotation = (schema: ZodTypeAny) => {
+  const annotations = getAnnotations(schema);
+  if (
+    isNonNullable(annotations) &&
+    isNonNullable(annotations.blueNode) &&
+    annotations.blueNode === true
+  ) {
+    return annotations.blueNode;
+  }
+  return null;
+};
+
+export const blueNodeField = () => {
+  const blueNodeFieldSchema = z.instanceof(BlueNode);
+  return withBlueNode()(blueNodeFieldSchema);
+};

--- a/libs/language/src/lib/mapping/annotations/extends.ts
+++ b/libs/language/src/lib/mapping/annotations/extends.ts
@@ -1,0 +1,49 @@
+import { isNonNullable, isNullable } from '@blue-company/shared-utils';
+import { AnyZodObject, ZodType, ZodTypeAny } from 'zod';
+import { setAnnotations, getAnnotations } from './annotations';
+
+const key = 'extendedFrom';
+
+export const withExtendedFromSchema = <
+  Schema extends AnyZodObject = AnyZodObject,
+  BaseSchema extends ZodTypeAny = ZodTypeAny
+>({
+  schema,
+  baseSchema,
+}: {
+  schema: Schema;
+  baseSchema: BaseSchema;
+}) => {
+  const currentAnnotations = getAnnotations(schema) || {};
+
+  return setAnnotations(schema, {
+    ...currentAnnotations,
+    [key]: baseSchema,
+  });
+};
+
+export const getExtendedFromSchemaAnnotation = (schema: ZodTypeAny) => {
+  const annotations = getAnnotations(schema);
+  if (isNonNullable(annotations) && annotations[key]) {
+    return annotations[key] as ZodTypeAny;
+  }
+
+  return null;
+};
+
+export const isSchemaExtendedFrom = (
+  schema: ZodType,
+  baseSchema: ZodType
+): boolean => {
+  const extendedFrom = getExtendedFromSchemaAnnotation(schema);
+
+  if (isNullable(extendedFrom)) {
+    return false;
+  }
+
+  if (extendedFrom?._def === baseSchema?._def) {
+    return true;
+  }
+
+  return isSchemaExtendedFrom(extendedFrom, baseSchema);
+};

--- a/libs/language/src/lib/mapping/annotations/index.ts
+++ b/libs/language/src/lib/mapping/annotations/index.ts
@@ -1,0 +1,6 @@
+export * from './blueDescription';
+export * from './blueId';
+export * from './blueName';
+export * from './blueNode';
+export * from './typeBlueId';
+export * from './extends';

--- a/libs/language/src/lib/mapping/annotations/typeBlueId/index.ts
+++ b/libs/language/src/lib/mapping/annotations/typeBlueId/index.ts
@@ -1,0 +1,1 @@
+export * from './typeBlueId';

--- a/libs/language/src/lib/mapping/annotations/typeBlueId/proxySchema.ts
+++ b/libs/language/src/lib/mapping/annotations/typeBlueId/proxySchema.ts
@@ -1,0 +1,38 @@
+import {
+  objectInputType,
+  objectOutputType,
+  UnknownKeysParam,
+  ZodObject,
+  ZodRawShape,
+  ZodTypeAny,
+} from 'zod';
+import { withExtendedFromSchema } from '../extends';
+
+export const proxySchema = <
+  T extends ZodRawShape,
+  UnknownKeys extends UnknownKeysParam = UnknownKeysParam,
+  Catchall extends ZodTypeAny = ZodTypeAny,
+  Output = objectOutputType<T, Catchall, UnknownKeys>,
+  Input = objectInputType<T, Catchall, UnknownKeys>
+>(
+  schema: ZodObject<T, UnknownKeys, Catchall, Output, Input>
+) => {
+  return new Proxy(schema, {
+    get(target, prop, receiver) {
+      if (prop === 'extend') {
+        return function (
+          ...args: Parameters<typeof ZodObject.prototype.extend>
+        ) {
+          const extendedSchema = target.extend(...args);
+
+          return withExtendedFromSchema({
+            schema: extendedSchema,
+            baseSchema: target,
+          });
+        };
+      }
+
+      return Reflect.get(target, prop, receiver);
+    },
+  });
+};

--- a/libs/language/src/lib/mapping/annotations/typeBlueId/typeBlueId.ts
+++ b/libs/language/src/lib/mapping/annotations/typeBlueId/typeBlueId.ts
@@ -1,0 +1,56 @@
+import {
+  objectInputType,
+  objectOutputType,
+  UnknownKeysParam,
+  z,
+  ZodObject,
+  ZodRawShape,
+  ZodTypeAny,
+} from 'zod';
+import { getAnnotations, setAnnotations } from '../annotations';
+import { proxySchema } from './proxySchema';
+
+const typeBlueIdAnnotation = z.object({
+  value: z.array(z.string()).optional(),
+  defaultValue: z.string().optional(),
+});
+
+type TypeBlueIdAnnotation = z.infer<typeof typeBlueIdAnnotation>;
+
+export const getTypeBlueIdAnnotation = (schema: ZodTypeAny) => {
+  const annotations = getAnnotations(schema);
+  const result = typeBlueIdAnnotation
+    .passthrough()
+    .safeParse(annotations?.typeBlueId);
+  if (!result.success) {
+    return null;
+  }
+
+  return result.data;
+};
+
+export const withTypeBlueId =
+  (value: string | TypeBlueIdAnnotation) =>
+  <
+    T extends ZodRawShape,
+    UnknownKeys extends UnknownKeysParam = UnknownKeysParam,
+    Catchall extends ZodTypeAny = ZodTypeAny,
+    Output = objectOutputType<T, Catchall, UnknownKeys>,
+    Input = objectInputType<T, Catchall, UnknownKeys>
+  >(
+    schema: ZodObject<T, UnknownKeys, Catchall, Output, Input>
+  ) => {
+    const annotations = getAnnotations(schema);
+    const typeBlueIdAnnotation = (
+      typeof value === 'string' ? { value: [value] } : value
+    ) satisfies TypeBlueIdAnnotation;
+    const proxiedSchema = proxySchema(schema);
+
+    return setAnnotations(proxiedSchema, {
+      ...annotations,
+      typeBlueId: {
+        ...(annotations?.typeBlueId || {}),
+        ...typeBlueIdAnnotation,
+      },
+    });
+  };

--- a/libs/language/src/lib/mapping/index.ts
+++ b/libs/language/src/lib/mapping/index.ts
@@ -1,0 +1,3 @@
+export { NodeToObjectConverter } from './NodeToObjectConverter';
+export type { Converter } from './Converter';
+export { ConverterFactory } from './ConverterFactory';

--- a/libs/language/src/lib/mapping/serializeBlueAnnotated.ts
+++ b/libs/language/src/lib/mapping/serializeBlueAnnotated.ts
@@ -1,0 +1,117 @@
+import { ZodType, ZodObject, ZodTypeDef, AnyZodObject } from 'zod';
+import {
+  getBlueIdAnnotation,
+  getBlueNameAnnotation,
+  getBlueDescriptionAnnotation,
+  getTypeBlueIdAnnotation,
+} from './annotations';
+
+type BlueSerialized = Record<string, unknown>;
+
+export function serializeBlueAnnotated<T extends Record<string, unknown>>(
+  value: T,
+  schema: AnyZodObject | ZodType<T, ZodTypeDef, T>
+): Record<string, unknown> {
+  const typeBlueId = getTypeBlueIdAnnotation(schema);
+  const result: BlueSerialized = {};
+
+  if (typeBlueId && typeBlueId.value && typeBlueId.value[0]) {
+    result.type = { blueId: typeBlueId.value[0] };
+  }
+
+  if (!(schema instanceof ZodObject)) {
+    return {
+      ...result,
+      value,
+    };
+  }
+
+  const shape = schema.shape;
+  const processedFields = new Set<string>();
+
+  const merges: Record<
+    string,
+    { name?: unknown; description?: unknown; value?: unknown; items?: unknown }
+  > = {};
+
+  for (const propName of Object.keys(shape)) {
+    const fieldValue = value[propName];
+    if (fieldValue === undefined) {
+      continue;
+    }
+
+    const propSchema = shape[propName];
+    const blueIdAnn = getBlueIdAnnotation(propSchema);
+    const blueNameAnn = getBlueNameAnnotation(propSchema);
+    const blueDescAnn = getBlueDescriptionAnnotation(propSchema);
+
+    if (blueIdAnn) {
+      result[propName] = { blueId: String(fieldValue) };
+      processedFields.add(propName);
+      continue;
+    }
+
+    if (blueNameAnn) {
+      const targetFieldName = blueNameAnn;
+      merges[targetFieldName] ||= {};
+      merges[targetFieldName].name = fieldValue;
+
+      const targetFieldValue = value[targetFieldName];
+      if (Array.isArray(targetFieldValue) || targetFieldValue instanceof Set) {
+        merges[targetFieldName].items = Array.isArray(targetFieldValue)
+          ? targetFieldValue
+          : Array.from(targetFieldValue);
+      } else {
+        merges[targetFieldName].value = targetFieldValue;
+      }
+
+      processedFields.add(propName);
+      processedFields.add(targetFieldName);
+      continue;
+    }
+
+    if (blueDescAnn) {
+      const targetFieldName = blueDescAnn;
+      merges[targetFieldName] ||= {};
+      merges[targetFieldName].description = fieldValue;
+
+      const targetFieldValue = value[targetFieldName];
+      if (Array.isArray(targetFieldValue) || targetFieldValue instanceof Set) {
+        merges[targetFieldName].items = Array.isArray(targetFieldValue)
+          ? targetFieldValue
+          : Array.from(targetFieldValue);
+      } else {
+        merges[targetFieldName].value = targetFieldValue;
+      }
+
+      processedFields.add(propName);
+      processedFields.add(targetFieldName);
+      continue;
+    }
+  }
+
+  for (const [targetField, mergeObj] of Object.entries(merges)) {
+    result[targetField] = {
+      ...(mergeObj.name !== undefined ? { name: mergeObj.name } : {}),
+      ...(mergeObj.description !== undefined
+        ? { description: mergeObj.description }
+        : {}),
+      ...(mergeObj.items !== undefined
+        ? { items: mergeObj.items }
+        : mergeObj.value !== undefined
+        ? { value: mergeObj.value }
+        : {}),
+    };
+  }
+
+  for (const propName of Object.keys(shape)) {
+    if (processedFields.has(propName)) {
+      continue;
+    }
+
+    const fieldValue = value[propName];
+    result[propName] = fieldValue;
+  }
+
+  return result;
+}

--- a/libs/language/src/lib/utils/BlueIdResolver.ts
+++ b/libs/language/src/lib/utils/BlueIdResolver.ts
@@ -1,0 +1,36 @@
+import { ZodTypeAny } from 'zod';
+import { getTypeBlueIdAnnotation } from '../mapping/annotations';
+import { isNonNullable, isNullable } from '@blue-company/shared-utils';
+
+type TypeBlueIdAnnotation = ReturnType<typeof getTypeBlueIdAnnotation>;
+
+export class BlueIdResolver {
+  static resolveBlueId(schema: ZodTypeAny) {
+    const typeBlueIdAnnotation = getTypeBlueIdAnnotation(schema);
+    if (isNullable(typeBlueIdAnnotation)) {
+      return null;
+    }
+
+    const defaultValue = typeBlueIdAnnotation.defaultValue;
+    if (isNonNullable(defaultValue)) {
+      return defaultValue;
+    }
+
+    const value = typeBlueIdAnnotation.value?.[0];
+    if (isNonNullable(value)) {
+      return value;
+    }
+
+    return BlueIdResolver.getRepositoryBlueId(typeBlueIdAnnotation, schema);
+  }
+
+  static getRepositoryBlueId(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    annotation: TypeBlueIdAnnotation,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    schema: ZodTypeAny
+  ) {
+    throw new Error('Not implemented');
+    return null;
+  }
+}

--- a/libs/language/src/lib/utils/NodeToMapListOrValue.ts
+++ b/libs/language/src/lib/utils/NodeToMapListOrValue.ts
@@ -105,7 +105,7 @@ export class NodeToMapListOrValue {
     return result;
   }
 
-  private static handleValue(value: BlueNode['value']) {
+  static handleValue(value: BlueNode['value']) {
     if (isBigNumber(value)) {
       if (isBigIntegerNumber(value)) {
         const lowerBound = new Big(Number.MIN_SAFE_INTEGER.toString());

--- a/libs/language/src/lib/utils/TypeSchemaResolver.ts
+++ b/libs/language/src/lib/utils/TypeSchemaResolver.ts
@@ -1,0 +1,48 @@
+import { ZodTypeAny } from 'zod';
+import { isNonNullable, isNullable } from '@blue-company/shared-utils';
+import { BlueIdResolver } from './BlueIdResolver';
+import { BlueNode } from '../model/Node';
+import { BlueIdCalculator } from './BlueIdCalculator';
+
+export class TypeSchemaResolver {
+  private readonly blueIdMap = new Map<string, ZodTypeAny>();
+
+  constructor(schemas: ZodTypeAny[]) {
+    for (const schema of schemas) {
+      this.registerSchema(schema);
+    }
+  }
+
+  private registerSchema(schema: ZodTypeAny) {
+    const blueId = BlueIdResolver.resolveBlueId(schema);
+
+    if (isNonNullable(blueId)) {
+      if (this.blueIdMap.has(blueId)) {
+        throw new Error(`Duplicate BlueId value: ${blueId}`);
+      }
+      this.blueIdMap.set(blueId, schema);
+    }
+  }
+
+  public resolveSchema(node: BlueNode) {
+    const blueId = this.getEffectiveBlueId(node);
+    if (isNullable(blueId)) {
+      return null;
+    }
+    return this.blueIdMap.get(blueId);
+  }
+
+  private getEffectiveBlueId(node: BlueNode) {
+    const nodeType = node.getType();
+    if (isNonNullable(nodeType) && isNonNullable(nodeType.getBlueId())) {
+      return nodeType.getBlueId();
+    } else if (isNonNullable(nodeType)) {
+      return BlueIdCalculator.calculateBlueIdSync(nodeType);
+    }
+    return null;
+  }
+
+  public getBlueIdMap() {
+    return new Map(this.blueIdMap);
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blue-js/monorepo",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blue-js/monorepo",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "MIT",
       "workspaces": [
         "libs/*",
@@ -113,6 +113,7 @@
         "js-sha256": "0.11.0",
         "js-yaml": "4.1.0",
         "radash": "12.1.0",
+        "reflect-metadata": "0.2.2",
         "type-fest": "4.20.1",
         "zod": "3.23.8"
       }
@@ -2890,6 +2891,17 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
+      "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
@@ -4586,6 +4598,28 @@
         "@types/responselike": "^1.0.0"
       }
     },
+    "node_modules/@types/eslint": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@types/eslint-scope": {
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/eslint": "*",
+        "@types/estree": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
@@ -5874,11 +5908,186 @@
       "integrity": "sha512-q0xCiLkuWWQLzVrecPb0RMsNWyxICOjPrcrwxTUEHb1fsnvni4dcuyG7RT/Ie7VPTvnjzIaWzRMUBsrqNj/hhw==",
       "dev": true
     },
+    "node_modules/@webassemblyjs/ast": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+      "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/helper-numbers": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/floating-point-hex-parser": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+      "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-api-error": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+      "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-buffer": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+      "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-numbers": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+      "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/floating-point-hex-parser": "1.13.2",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+      "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-wasm-section": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+      "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/wasm-gen": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/ieee754": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+      "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@xtuc/ieee754": "^1.2.0"
+      }
+    },
+    "node_modules/@webassemblyjs/leb128": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+      "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/utf8": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+      "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/wasm-edit": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+      "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/helper-wasm-section": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-opt": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1",
+        "@webassemblyjs/wast-printer": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-gen": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+      "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-opt": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+      "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-parser": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+      "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/wast-printer": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+      "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@xtuc/long": "4.2.2"
+      }
+    },
     "node_modules/@webpro/nx-tsc": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/@webpro/nx-tsc/-/nx-tsc-0.0.2.tgz",
       "integrity": "sha512-NEiFysGXhNpgJuAGU33L7/7jwbeD0EXQy97n/nXMt1ix/jvNL98C+Vx6FuqaOyE4tjaqvpPa9TVl/Q2R0Loo1g==",
       "dev": true
+    },
+    "node_modules/@xtuc/ieee754": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@xtuc/long": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
@@ -6026,6 +6235,58 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "dev": true,
+      "peer": true,
+      "peerDependencies": {
+        "ajv": "^6.9.1"
       }
     },
     "node_modules/ansi-colors": {
@@ -6994,6 +7255,16 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/chrome-trace-event": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
+      "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6.0"
       }
     },
     "node_modules/clean-stack": {
@@ -8083,6 +8354,20 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/enhanced-resolve": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.0.tgz",
+      "integrity": "sha512-0/r0MySGYG8YqlayBZ6MuCfECmHFdJ5qyPh8s8wa5Hnm6SaFLSK1VYCbj+NKp090Nm1caZhD+QTnmxO7esYGyQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/enquirer": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
@@ -8145,6 +8430,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
+      "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -8811,6 +9103,13 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true
     },
+    "node_modules/fast-uri": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
+      "integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/fastq": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
@@ -9372,6 +9671,13 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/glob/node_modules/minimatch": {
       "version": "10.0.1",
@@ -10442,6 +10748,37 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-worker": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/jju": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
@@ -10855,6 +11192,16 @@
       "dev": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/loader-runner": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
+      "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6.11.5"
       }
     },
     "node_modules/loader-utils": {
@@ -13225,6 +13572,16 @@
         "node": ">=14.18.0"
       }
     },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -13831,6 +14188,25 @@
         "node": ">=v12.22.7"
       }
     },
+    "node_modules/schema-utils": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/secure-compare": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
@@ -13920,6 +14296,16 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
     },
     "node_modules/serve-static": {
       "version": "1.15.0",
@@ -14518,6 +14904,16 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
+    "node_modules/tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tar-stream": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
@@ -14532,6 +14928,145 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/terser": {
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.37.0.tgz",
+      "integrity": "sha512-B8wRRkmre4ERucLM/uXx4MOV5cbnOlVAqUst+1+iLKPI0dOgFO28f84ptoQt9HEI537PMzfYa/d+GEPKTRXmYA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.8.2",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser-webpack-plugin": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.11.tgz",
+      "integrity": "sha512-RVCsMfuD0+cTt3EwX8hSl2Ks56EbFHWmhluwcqoPKtBnfjiT6olaq7PRIRfhyU8nnC2MrnDrBLfrD/RGE+cVXQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jest-worker": "^27.4.5",
+        "schema-utils": "^4.3.0",
+        "serialize-javascript": "^6.0.2",
+        "terser": "^5.31.1"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "uglify-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/terser-webpack-plugin/node_modules/schema-utils": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
+      "integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/terser/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/terser/node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/test-exclude": {
@@ -15900,6 +16435,20 @@
         "node": ">=18"
       }
     },
+    "node_modules/watchpack": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
+      "integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -15914,6 +16463,94 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "dev": true
+    },
+    "node_modules/webpack": {
+      "version": "5.97.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.1.tgz",
+      "integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/eslint-scope": "^3.7.7",
+        "@types/estree": "^1.0.6",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
+        "acorn": "^8.14.0",
+        "browserslist": "^4.24.0",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^5.17.1",
+        "es-module-lexer": "^1.2.1",
+        "eslint-scope": "5.1.1",
+        "events": "^3.2.0",
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.2.11",
+        "json-parse-even-better-errors": "^2.3.1",
+        "loader-runner": "^4.2.0",
+        "mime-types": "^2.1.27",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^3.2.0",
+        "tapable": "^2.1.1",
+        "terser-webpack-plugin": "^5.3.10",
+        "watchpack": "^2.4.1",
+        "webpack-sources": "^3.2.3"
+      },
+      "bin": {
+        "webpack": "bin/webpack.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-sources": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webpack/node_modules/@types/estree": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/webpack/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/webpack/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=4.0"
+      }
     },
     "node_modules/whatwg-encoding": {
       "version": "2.0.0",


### PR DESCRIPTION
Adds a new mapping system that converts BlueNode objects to TypeScript objects using Zod schemas. Includes:

- Converter interfaces and implementations for primitive types, arrays, maps, sets
- Complex object converter with support for inheritance and annotations
- Value conversion utilities
- Factory pattern for converter instantiation