### PR TITLE
feat: add MyOSAgentChannelProcessor and related schemas

### DIFF
--- a/libs/language/src/lib/Blue.ts
+++ b/libs/language/src/lib/Blue.ts
@@ -25,6 +25,7 @@ import {
   TimelineChannelProcessor,
   SequentialWorkflowProcessor,
   MyOSTimelineChannelProcessor,
+  MyOSAgentChannelProcessor,
 } from './processor/processors';
 import { EventNodePayload } from './processor/types';
 
@@ -68,6 +69,7 @@ export class Blue {
       new DocumentUpdateChannelProcessor(),
       new TimelineChannelProcessor(),
       new MyOSTimelineChannelProcessor(),
+      new MyOSAgentChannelProcessor(),
       new CompositeTimelineChannelProcessor(),
       new SequentialWorkflowProcessor(),
     ]);

--- a/libs/language/src/lib/processor/processors/MyOSAgentChannelProcessor.ts
+++ b/libs/language/src/lib/processor/processors/MyOSAgentChannelProcessor.ts
@@ -1,0 +1,56 @@
+import { EventNode, DocumentNode, ProcessingContext } from '../types';
+import { isNonNullable } from '../utils/typeGuard';
+import { BaseChannelProcessor } from './BaseChannelProcessor';
+import {
+  blueIds,
+  MyOSAgentEventSchema,
+  MyOSAgentChannelSchema,
+} from '../../../repo/myos';
+
+/* ------------------------------------------------------------------------ */
+/* MyOS Agent Channel – processes MyOS Agent Events                        */
+/* ------------------------------------------------------------------------ */
+export class MyOSAgentChannelProcessor extends BaseChannelProcessor {
+  readonly contractType = 'MyOS Agent Channel';
+  readonly contractBlueId = blueIds['MyOS Agent Channel'];
+
+  supports(
+    event: EventNode,
+    node: DocumentNode,
+    ctx: ProcessingContext
+  ): boolean {
+    if (!this.baseSupports(event)) return false;
+
+    const blue = ctx.getBlue();
+
+    const eventPayloadNode = blue.jsonValueToNode(event.payload);
+    const myosAgentEvent = blue.nodeToSchemaOutput(
+      eventPayloadNode,
+      MyOSAgentEventSchema
+    );
+    const myosAgentChannel = ctx
+      .getBlue()
+      .nodeToSchemaOutput(node, MyOSAgentChannelSchema);
+
+    const hasAgent =
+      isNonNullable(myosAgentChannel.agent?.agentId) &&
+      isNonNullable(myosAgentEvent.agentId);
+
+    return (
+      hasAgent && myosAgentEvent.agentId === myosAgentChannel.agent?.agentId
+    );
+  }
+
+  handle(
+    event: EventNode,
+    node: DocumentNode,
+    ctx: ProcessingContext,
+    path: string
+  ): void {
+    ctx.emitEvent({
+      payload: event.payload,
+      channelName: path,
+      source: 'channel',
+    });
+  }
+}

--- a/libs/language/src/lib/processor/processors/__tests__/MyOSAgentChannelProcessor.test.ts
+++ b/libs/language/src/lib/processor/processors/__tests__/MyOSAgentChannelProcessor.test.ts
@@ -1,0 +1,106 @@
+import { MyOSAgentChannelProcessor } from '../MyOSAgentChannelProcessor';
+import { EventNode, ProcessingContext } from '../../types';
+import { NodeDeserializer } from '../../../model';
+import { Blue } from '../../../Blue';
+
+describe('MyOSAgentChannelProcessor', () => {
+  let processor: MyOSAgentChannelProcessor;
+  let mockContext: ProcessingContext;
+  const mockNode = NodeDeserializer.deserialize({
+    type: 'MyOS Agent Channel',
+    agent: {
+      agentId: 'test-1234',
+    },
+    event: {
+      type: 'SomeEventType',
+      payload: { foo: 'bar' },
+    },
+  });
+
+  beforeEach(() => {
+    processor = new MyOSAgentChannelProcessor();
+
+    mockContext = {
+      getBlue: vi.fn().mockReturnValue(new Blue()),
+      emitEvent: vi.fn(),
+      resolvePath: vi.fn(),
+      getNodePath: vi.fn(),
+    } as any;
+  });
+
+  describe('supports', () => {
+    it('should return true for matching MyOS Agent Event with correct agentId', () => {
+      const event: EventNode = {
+        payload: {
+          type: 'MyOS Agent Event',
+          agentId: 'test-1234',
+          id: 18440,
+          timestamp: 1748598263552984,
+          event: {
+            type: 'SomeEventType',
+            payload: { foo: 'bar' },
+          },
+        },
+        source: 'external',
+      };
+
+      const result = processor.supports(event, mockNode, mockContext);
+      expect(result).toBe(true);
+    });
+
+    it('should return false for non-matching agentId', () => {
+      const event: EventNode = {
+        payload: {
+          type: 'MyOS Agent Event',
+          agentId: 'different-agent',
+          id: 18440,
+          timestamp: 1748598263552984,
+          event: { type: 'SomeEventType', payload: { foo: 'bar' } },
+        },
+        source: 'external',
+      };
+
+      const result = processor.supports(event, mockNode, mockContext);
+      expect(result).toBe(false);
+    });
+
+    it('should return false for channel events', () => {
+      const event: EventNode = {
+        payload: {
+          type: 'MyOS Agent Event',
+          agentId: 'test-1234',
+          id: 18440,
+          timestamp: 1748598263552984,
+          event: { type: 'SomeEventType', payload: { foo: 'bar' } },
+        },
+        source: 'channel',
+      };
+
+      const result = processor.supports(event, mockNode, mockContext);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('handle', () => {
+    it('should emit event with channel source and channelName', () => {
+      const event: EventNode = {
+        payload: {
+          type: 'MyOS Agent Event',
+          agentId: 'test-1234',
+          id: 18440,
+          timestamp: 1748598263552984,
+          event: { type: 'SomeEventType', payload: { foo: 'bar' } },
+        },
+        source: 'external',
+      };
+
+      processor.handle(event, mockNode, mockContext, 'someAgentChannel');
+
+      expect(mockContext.emitEvent).toHaveBeenCalledWith({
+        payload: event.payload,
+        channelName: 'someAgentChannel',
+        source: 'channel',
+      });
+    });
+  });
+});

--- a/libs/language/src/lib/processor/processors/index.ts
+++ b/libs/language/src/lib/processor/processors/index.ts
@@ -3,6 +3,7 @@ export * from './CompositeTimelineChannelProcessor';
 export * from './DocumentUpdateChannelProcessor';
 export * from './EmbeddedNodeChannelProcessor';
 export * from './MyOSTimelineChannelProcessor';
+export * from './MyOSAgentChannelProcessor';
 export * from './ProcessEmbeddedProcessor';
 export * from './TimelineChannelProcessor';
 export * from './SequentialWorkflowProcessor';

--- a/libs/language/src/repo/myos/blue-ids/index.ts
+++ b/libs/language/src/repo/myos/blue-ids/index.ts
@@ -1,4 +1,7 @@
 export const blueIds = {
   'MyOS Timeline Channel': 'MkKoutP5qxkh3uDxZ7dr6Eo27B7fuxQCS1VAptiCPc2R',
   'MyOS Timeline Entry': 'uDxZ7dr6Eo2MkKoutP5qxkh3uxQCS1VAptiCPc2R7B7f',
+  'MyOS Agent': 'AgentBlu3Id7dr6Eo2MkKoutP5qxkh3uxQCS1V',
+  'MyOS Agent Channel': 'AgentCh4nn3lBlu3Id7dr6Eo2MkKoutP5qxkh3uxQCS1V',
+  'MyOS Agent Event': 'AgentEv3ntBlu3Id7dr6Eo2MkKoutP5qxkh3uxQCS1V',
 } as const;

--- a/libs/language/src/repo/myos/schema/MyOSAgent.ts
+++ b/libs/language/src/repo/myos/schema/MyOSAgent.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+import { blueIds } from '../blue-ids';
+import { withTypeBlueId } from '../../../schema/annotations/typeBlueId';
+
+export const MyOSAgentSchema = withTypeBlueId(blueIds['MyOS Agent'])(
+  z.object({
+    agentId: z.string().optional(),
+  })
+);
+
+export type MyOSAgent = z.infer<typeof MyOSAgentSchema>;

--- a/libs/language/src/repo/myos/schema/MyOSAgentChannel.ts
+++ b/libs/language/src/repo/myos/schema/MyOSAgentChannel.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+import { blueIds } from '../blue-ids';
+import { withTypeBlueId } from '../../../schema/annotations/typeBlueId';
+import { ChannelSchema } from '../../core';
+import { blueNodeField } from 'src/schema/annotations';
+import { MyOSAgentSchema } from './MyOSAgent';
+
+export const MyOSAgentChannelSchema = withTypeBlueId(
+  blueIds['MyOS Agent Channel']
+)(
+  ChannelSchema.extend({
+    agent: MyOSAgentSchema.optional(),
+    event: blueNodeField().optional(),
+  })
+);
+
+export type MyOSAgentChannel = z.infer<typeof MyOSAgentChannelSchema>;

--- a/libs/language/src/repo/myos/schema/MyOSAgentEvent.ts
+++ b/libs/language/src/repo/myos/schema/MyOSAgentEvent.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+import { blueIds } from '../blue-ids';
+import { withTypeBlueId } from '../../../schema/annotations/typeBlueId';
+import { blueNodeField } from 'src/schema/annotations';
+
+export const MyOSAgentEventSchema = withTypeBlueId(blueIds['MyOS Agent Event'])(
+  z.object({
+    agentId: z.string().optional(),
+    id: z.number().optional(),
+    timestamp: z.number().optional(),
+    event: blueNodeField().optional(),
+  })
+);
+
+export type MyOSAgentEvent = z.infer<typeof MyOSAgentEventSchema>;

--- a/libs/language/src/repo/myos/schema/index.ts
+++ b/libs/language/src/repo/myos/schema/index.ts
@@ -1,2 +1,5 @@
 export * from './MyOSTimelineChannel';
 export * from './MyOSTimelineEntry';
+export * from './MyOSAgent';
+export * from './MyOSAgentChannel';
+export * from './MyOSAgentEvent';


### PR DESCRIPTION
- Introduced MyOSAgentChannelProcessor for processing MyOS Agent events.
- Added schemas for MyOSAgent, MyOSAgentChannel, and MyOSAgentEvent to support new event types.
- Updated Blue class and processor exports to include the new processor and schemas.
- Implemented unit tests for MyOSAgentChannelProcessor to ensure correct event handling and support logic.