### PR TITLE
fix: improve node crypto checks in CryptoEnvironment

### DIFF
--- a/libs/language/src/lib/utils/CryptoEnvironment.ts
+++ b/libs/language/src/lib/utils/CryptoEnvironment.ts
@@ -33,7 +33,9 @@ export class CryptoEnvironment {
   }
 
   hasNodeCrypto(): boolean {
-    return !!nodeCrypto.createHash;
+    return (
+      isNode && !!nodeCrypto && typeof nodeCrypto.createHash === 'function'
+    );
   }
 
   getBrowserCrypto(): Crypto | null {
@@ -41,6 +43,6 @@ export class CryptoEnvironment {
   }
 
   getNodeCrypto(): Crypto | null {
-    return nodeCrypto;
+    return isNode ? nodeCrypto : null;
   }
 }


### PR DESCRIPTION
- Updated the `hasNodeCrypto` method to ensure `nodeCrypto` is defined and that `createHash` is a function.
- Modified the `getNodeCrypto` method to return `null` if not in a Node environment, enhancing compatibility and error handling.