### PR TITLE
fix: use _def.typeName instead of constructor.name for zod schema types

### DIFF
--- a/libs/language/src/lib/mapping/ComplexObjectConverter.ts
+++ b/libs/language/src/lib/mapping/ComplexObjectConverter.ts
@@ -159,6 +159,6 @@ export class ComplexObjectConverter implements Converter {
       return result;
     }
 
-    throw new Error('Unknown schema type, ' + schema.constructor.name);
+    throw new Error('Unknown schema type, ' + schema._def.typeName);
   }
 }

--- a/libs/language/src/lib/mapping/ConverterFactory.ts
+++ b/libs/language/src/lib/mapping/ConverterFactory.ts
@@ -113,7 +113,7 @@ export class ConverterFactory {
       return this.getSchemaTypeName(schema.unwrap());
     }
 
-    const schemaTypeName = schema.constructor.name;
+    const schemaTypeName = schema._def.typeName;
 
     try {
       const parsedSchemaTypeName =

--- a/libs/language/src/lib/mapping/ValueConverter.ts
+++ b/libs/language/src/lib/mapping/ValueConverter.ts
@@ -78,9 +78,7 @@ export class ValueConverter {
       return BigInt(value);
     }
 
-    throw new Error(
-      `Cannot convert String to ${targetSchema.constructor.name}`
-    );
+    throw new Error(`Cannot convert String to ${targetSchema._def.typeName}`);
   }
 
   private static convertFromBigDecimal(
@@ -95,9 +93,7 @@ export class ValueConverter {
       return value.toString();
     }
 
-    throw new Error(
-      `Cannot convert Number to ${targetSchema.constructor.name}`
-    );
+    throw new Error(`Cannot convert Number to ${targetSchema._def.typeName}`);
   }
 
   private static convertFromBigInteger(
@@ -116,9 +112,7 @@ export class ValueConverter {
       return value.toString();
     }
 
-    throw new Error(
-      `Cannot convert Number to ${targetSchema.constructor.name}`
-    );
+    throw new Error(`Cannot convert Number to ${targetSchema._def.typeName}`);
   }
 
   private static convertFromBoolean(value: boolean, targetSchema: ZodTypeAny) {
@@ -140,9 +134,7 @@ export class ValueConverter {
       return BigInt(value);
     }
 
-    throw new Error(
-      `Cannot convert Boolean to ${targetSchema.constructor.name}`
-    );
+    throw new Error(`Cannot convert Boolean to ${targetSchema._def.typeName}`);
   }
 
   private static isPrimitive(targetSchema: ZodTypeAny) {
@@ -168,7 +160,7 @@ export class ValueConverter {
     }
 
     throw new Error(
-      `Unsupported primitive type: ${targetSchema.constructor.name}`
+      `Unsupported primitive type: ${targetSchema._def.typeName}`
     );
   }
 }


### PR DESCRIPTION
Replace constructor.name with _def.typeName across mapping converters to ensure reliable schema type identification in error messages.

The constructor.name property is unreliable because:
- It gets mangled during code minification (e.g., ZodString becomes 'a')
- Behavior varies across JavaScript engines and build environments
- Not the official Zod API for schema type identification

Using _def.typeName provides:
- Consistent schema type names in all environments
- Minification-safe error messages
- Alignment with Zod's internal schema identification system
- More reliable debugging experience in production builds

This ensures error messages like "Unknown schema type, ZodString" remain meaningful even in minified production code.