### PR TITLE
feat(language/merge): add MetadataPropagator and ensure type message.…

### DIFF
--- a/libs/document-processor/src/processors/__tests__/JavaScriptCodeStep.integration.test.ts
+++ b/libs/document-processor/src/processors/__tests__/JavaScriptCodeStep.integration.test.ts
@@ -1,0 +1,93 @@
+import { describe, test, expect } from 'vitest';
+import { Blue } from '@blue-labs/language';
+import { BlueDocumentProcessor } from '../../BlueDocumentProcessor';
+import { JsonObject } from '@blue-labs/shared-utils';
+import { repository as coreRepository } from '@blue-repository/core-dev';
+import { repository as myosRepository } from '@blue-repository/myos-dev';
+
+describe('MyOS Timeline Channel + JavaScript Code step — merger resolve and expression evaluation"', () => {
+  const blue = new Blue({ repositories: [coreRepository, myosRepository] });
+  const documentProcessor = new BlueDocumentProcessor(blue);
+
+  test("executes when message is an object and event.message.name === 'Start' (after merger resolve)", async () => {
+    const doc: JsonObject = {
+      contracts: {
+        channelName: {
+          type: 'MyOS Timeline Channel',
+          timelineId: 'timeline-1',
+        },
+        counterWorkflow: {
+          type: 'Sequential Workflow',
+          channel: 'channelName',
+          steps: [
+            {
+              name: 'EmitEvent',
+              type: 'JavaScript Code',
+              code: `return { events: event.message && event.message.name === 'Start' ? [{ name: 'X' }] : [] };`,
+            },
+          ],
+        },
+      },
+    };
+
+    const initial = await documentProcessor.initialize(
+      blue.jsonValueToNode(doc)
+    );
+
+    const event = blue.resolve(
+      blue.jsonValueToNode({
+        type: 'MyOS Timeline Entry',
+        timeline: {
+          timelineId: 'timeline-1',
+        },
+        message: { name: 'Start' },
+        timestamp: 1749540750150,
+      })
+    );
+
+    const { emitted } = await documentProcessor.processEvents(initial.state, [
+      event,
+    ]);
+    expect(emitted.length).toEqual(1);
+  });
+
+  test("executes when message is a string and event.message === 'Start'", async () => {
+    const doc: JsonObject = {
+      contracts: {
+        channelName: {
+          type: 'MyOS Timeline Channel',
+          timelineId: 'timeline-1',
+        },
+        counterWorkflow: {
+          type: 'Sequential Workflow',
+          channel: 'channelName',
+          steps: [
+            {
+              name: 'EmitEvent',
+              type: 'JavaScript Code',
+              code: `return { events: event.message === 'Start' ? [{ name: 'X' }] : [] };`,
+            },
+          ],
+        },
+      },
+    };
+
+    const initial = await documentProcessor.initialize(
+      blue.jsonValueToNode(doc)
+    );
+
+    const event = blue.jsonValueToNode({
+      type: 'MyOS Timeline Entry',
+      timeline: {
+        timelineId: 'timeline-1',
+      },
+      message: 'Start',
+      timestamp: 1749540750150,
+    });
+
+    const { emitted } = await documentProcessor.processEvents(initial.state, [
+      event,
+    ]);
+    expect(emitted.length).toEqual(1);
+  });
+});

--- a/libs/language/src/lib/merge/processors/MetadataPropagator.ts
+++ b/libs/language/src/lib/merge/processors/MetadataPropagator.ts
@@ -1,0 +1,29 @@
+import { BlueNode } from '../../model';
+import { MergingProcessor } from '../MergingProcessor';
+
+/**
+ * Propagates metadata (name, description) from source to target when target is missing it.
+ *
+ * This ensures that when a source node provides metadata (e.g., payload-provided
+ * `name`), it is preserved after merging with type-provided nodes which typically
+ * carry descriptions but not names.
+ */
+export class MetadataPropagator implements MergingProcessor {
+  process(target: BlueNode, source: BlueNode): BlueNode {
+    let newTarget = target;
+
+    const sourceName = source.getName();
+    const targetName = target.getName();
+    if (sourceName !== undefined && targetName === undefined) {
+      newTarget = newTarget.clone().setName(sourceName);
+    }
+
+    const sourceDescription = source.getDescription();
+    const targetDescription = newTarget.getDescription();
+    if (sourceDescription !== undefined && targetDescription === undefined) {
+      newTarget = newTarget.clone().setDescription(sourceDescription);
+    }
+
+    return newTarget;
+  }
+}

--- a/libs/language/src/lib/merge/processors/index.ts
+++ b/libs/language/src/lib/merge/processors/index.ts
@@ -4,3 +4,4 @@ export * from './TypeAssigner';
 export * from './ListProcessor';
 export * from './DictionaryProcessor';
 export * from './BasicTypesVerifier';
+export * from './MetadataPropagator';

--- a/libs/language/src/lib/merge/utils/default.ts
+++ b/libs/language/src/lib/merge/utils/default.ts
@@ -6,6 +6,7 @@ import {
   ListProcessor,
   DictionaryProcessor,
   BasicTypesVerifier,
+  MetadataPropagator,
 } from '../processors';
 
 /**
@@ -18,6 +19,7 @@ export function createDefaultMergingProcessor(): MergingProcessor {
     new TypeAssigner(),
     new ListProcessor(),
     new DictionaryProcessor(),
+    new MetadataPropagator(),
     new BasicTypesVerifier(),
   ]);
 }


### PR DESCRIPTION
…name precedence

- Add MetadataPropagator to default merging pipeline to propagate name/description from source only when target metadata is missing
- Wire MetadataPropagator into processors index and default factory
- Add language integration tests:
  - propagates metadata from source when target lacks it
  - prefers type-provided message.name over source-provided name
- Add document-processor integration tests for JavaScript Code step:
  - emits when event.message is an object and event.message.name === 'Start'
  - emits when event.message is a string and event.message === 'Start'