### PR TITLE
feat(language): support implicit List/Dictionary structure and enforc…

### DIFF
--- a/libs/document-processor/src/processors/__tests__/DocumentSessionBootstrap.integration.test.ts
+++ b/libs/document-processor/src/processors/__tests__/DocumentSessionBootstrap.integration.test.ts
@@ -38,16 +38,13 @@ describe('Document Session Bootstrap integration', () => {
       message: {
         type: 'Operation Request',
         operation: 'myOsAdminUpdate',
-        request: {
-          type: 'List',
-          items: [
-            {
-              type: 'Participant Resolved',
-              channelName: 'alice',
-              participant: { status: { accountStatus: 'Active' } },
-            },
-          ],
-        },
+        request: [
+          {
+            type: 'Participant Resolved',
+            channelName: 'alice',
+            participant: { status: { accountStatus: 'Active' } },
+          },
+        ],
       },
     });
 
@@ -76,15 +73,12 @@ describe('Document Session Bootstrap integration', () => {
       message: {
         type: 'Operation Request',
         operation: 'myOsAdminUpdate',
-        request: {
-          type: 'List',
-          items: [
-            {
-              type: 'Target Document Session Started',
-              initiatorSessionId: 'sess-123',
-            },
-          ],
-        },
+        request: [
+          {
+            type: 'Target Document Session Started',
+            initiatorSessionId: 'sess-123',
+          },
+        ],
       },
     });
 
@@ -112,10 +106,7 @@ describe('Document Session Bootstrap integration', () => {
       message: {
         type: 'Operation Request',
         operation: 'myOsAdminUpdate',
-        request: {
-          type: 'List',
-          items: [{ type: 'Bootstrap Failed', reason: 'Something went wrong' }],
-        },
+        request: [{ type: 'Bootstrap Failed', reason: 'Something went wrong' }],
       },
     });
 

--- a/libs/language/src/lib/utils/NodeTypeMatcher.ts
+++ b/libs/language/src/lib/utils/NodeTypeMatcher.ts
@@ -16,6 +16,12 @@ export class NodeTypeMatcher {
     targetType: BlueNode,
     globalLimits: Limits = NO_LIMITS
   ): boolean {
+    // Quick structural match for implicit core types (List/Dictionary)
+    const quickTargetType = targetType.getType();
+    if (this.matchesImplicitStructure(node, quickTargetType)) {
+      return true;
+    }
+
     // Derive path limits from the target type structure
     const pathLimits = PathLimits.fromNode(targetType);
     const compositeLimits = CompositeLimits.of(globalLimits, pathLimits);
@@ -29,10 +35,71 @@ export class NodeTypeMatcher {
     );
   }
 
+  /**
+   * Resolves a node with the runtime while preserving any structure that could
+   * be dropped during resolution (items, properties, identifiers, values).
+   */
   private extendAndResolve(node: BlueNode, limits: Limits): BlueNode {
-    const extendedNode = node.clone();
-    this.blue.extend(extendedNode, limits);
-    return this.blue.resolve(extendedNode, limits);
+    const originalClone = node.clone();
+    const extendedClone = originalClone.clone();
+
+    this.blue.extend(extendedClone, limits);
+    const resolved = this.blue.resolve(extendedClone, limits);
+
+    this.restoreMissingStructure(resolved, originalClone);
+
+    return resolved;
+  }
+
+  /**
+   * Recursively copies structural information from the original node to the
+   * resolved node so comparisons can still see user-provided shape data.
+   */
+  private restoreMissingStructure(target: BlueNode, source: BlueNode): void {
+    const sourceItems = source.getItems();
+    const targetItems = target.getItems();
+
+    if (sourceItems && sourceItems.length > 0) {
+      if (!targetItems || targetItems.length === 0) {
+        target.setItems(sourceItems.map((item) => item.clone()));
+      } else {
+        for (
+          let i = 0;
+          i < Math.min(targetItems.length, sourceItems.length);
+          i++
+        ) {
+          this.restoreMissingStructure(targetItems[i], sourceItems[i]);
+        }
+      }
+    }
+
+    const sourceProps = source.getProperties();
+    if (sourceProps) {
+      let targetProps = target.getProperties();
+      if (!targetProps) {
+        targetProps = {};
+        target.setProperties(targetProps);
+      }
+
+      for (const [key, value] of Object.entries(sourceProps)) {
+        const targetValue = targetProps[key];
+        if (targetValue === undefined) {
+          targetProps[key] = value.clone();
+        } else {
+          this.restoreMissingStructure(targetValue, value);
+        }
+      }
+    }
+
+    const sourceBlueId = source.getBlueId();
+    if (target.getBlueId() === undefined && sourceBlueId !== undefined) {
+      target.setBlueId(sourceBlueId);
+    }
+
+    const sourceValue = source.getValue();
+    if (target.getValue() === undefined && sourceValue !== undefined) {
+      target.setValue(sourceValue);
+    }
   }
 
   private verifyMatch(
@@ -40,6 +107,12 @@ export class NodeTypeMatcher {
     targetType: BlueNode,
     limits: Limits
   ): boolean {
+    // Fast-path: allow implicit structural match for core List/Dictionary when node lacks explicit type
+    const targetTypeType = targetType.getType();
+    if (this.matchesImplicitStructure(resolvedNode, targetTypeType)) {
+      return true;
+    }
+
     const testNode = resolvedNode.clone().setType(targetType.clone());
     try {
       this.blue.resolve(testNode, limits);
@@ -54,10 +127,16 @@ export class NodeTypeMatcher {
     targetType: BlueNode
   ): boolean {
     const targetTypeType = targetType.getType();
-    if (targetTypeType) {
+    const isImplicitStructureMatch = this.matchesImplicitStructure(
+      node,
+      targetTypeType
+    );
+    if (targetTypeType && !isImplicitStructureMatch) {
       const nodeType = node.getType();
+      if (!nodeType) {
+        return false;
+      }
       if (
-        !nodeType ||
         !NodeTypes.isSubtype(
           nodeType,
           targetTypeType,
@@ -69,8 +148,23 @@ export class NodeTypeMatcher {
     }
 
     const targetBlueId = targetType.getBlueId();
-    if (targetBlueId !== undefined && targetBlueId !== node.getBlueId()) {
-      return false;
+    if (!isImplicitStructureMatch) {
+      if (targetBlueId !== undefined) {
+        const nodeBlueId = node.getBlueId();
+        const nodeTypeBlueId = node.getType()?.getBlueId();
+        if (nodeBlueId !== undefined) {
+          if (targetBlueId !== nodeBlueId) {
+            return false;
+          }
+        } else {
+          if (nodeTypeBlueId === undefined) {
+            return false;
+          }
+          if (targetBlueId !== nodeTypeBlueId) {
+            return false;
+          }
+        }
+      }
     }
 
     const targetValue = targetType.getValue();
@@ -104,7 +198,16 @@ export class NodeTypeMatcher {
         }
       }
       // no need to check extra items on node
-      return true;
+    }
+
+    const targetItemType = targetType.getItemType();
+    if (targetItemType !== undefined) {
+      const nodeItems = node.getItems() ?? [];
+      for (const item of nodeItems) {
+        if (!this.recursiveValueComparison(item, targetItemType)) {
+          return false;
+        }
+      }
     }
 
     const targetProps = targetType.getProperties();
@@ -121,7 +224,16 @@ export class NodeTypeMatcher {
           }
         }
       }
-      return true;
+    }
+
+    const targetValueType = targetType.getValueType();
+    if (targetValueType !== undefined) {
+      const nodeProps = Object.values(node.getProperties() ?? {});
+      for (const value of nodeProps) {
+        if (!this.recursiveValueComparison(value, targetValueType)) {
+          return false;
+        }
+      }
     }
 
     return true;
@@ -151,5 +263,36 @@ export class NodeTypeMatcher {
     }
 
     return false;
+  }
+
+  /**
+   * Determines whether a node without an explicit type already satisfies the
+   * shape of the requested core list or dictionary type.
+   */
+  private matchesImplicitStructure(
+    node: BlueNode,
+    targetTypeType: BlueNode | undefined
+  ): boolean {
+    if (targetTypeType === undefined || node.getType() !== undefined) {
+      return false;
+    }
+
+    if (NodeTypes.isListType(targetTypeType)) {
+      return this.isImplicitListStructure(node);
+    }
+
+    if (NodeTypes.isDictionaryType(targetTypeType)) {
+      return this.isImplicitDictionaryStructure(node);
+    }
+
+    return false;
+  }
+
+  private isImplicitListStructure(node: BlueNode): boolean {
+    return node.getItems() !== undefined && node.getValue() === undefined;
+  }
+
+  private isImplicitDictionaryStructure(node: BlueNode): boolean {
+    return node.getProperties() !== undefined && node.getValue() === undefined;
   }
 }

--- a/libs/language/src/lib/utils/__tests__/NodeTypeMatcher.test.ts
+++ b/libs/language/src/lib/utils/__tests__/NodeTypeMatcher.test.ts
@@ -1,6 +1,8 @@
 import { Blue } from '../../Blue';
 import { BasicNodeProvider } from '../../provider/BasicNodeProvider';
+import { BlueNode } from '../../model';
 import { NodeTypeMatcher } from '../NodeTypeMatcher';
+import { DICTIONARY_TYPE_BLUE_ID } from '../Properties';
 
 describe('NodeTypeMatcher', () => {
   test('basic type/value/shape cases (no constraints)', () => {
@@ -153,4 +155,193 @@ x:
   blueId: ${betaId}`;
     expect(matcher.matchesType(node, blue.yamlToNode(fail))).toBe(false);
   });
+
+  test('list itemType enforces item shape', () => {
+    const nodeProvider = new BasicNodeProvider();
+
+    const allowedItem = `name: Allowed Item
+value: ok`;
+    const forbiddenItem = `name: Forbidden Item
+value: not-ok`;
+    nodeProvider.addSingleDocs(allowedItem, forbiddenItem);
+
+    const allowedItemId = nodeProvider.getBlueIdByName('Allowed Item');
+    const forbiddenItemId = nodeProvider.getBlueIdByName('Forbidden Item');
+
+    const listWithAllowed = `name: Allowed Container
+itemsList:
+  type: List
+  items:
+    - blueId: ${allowedItemId}
+`; // simple case with a single allowed element
+
+    const listWithForbidden = `name: Forbidden Container
+itemsList:
+  type: List
+  items:
+    - blueId: ${forbiddenItemId}
+`;
+
+    nodeProvider.addSingleDocs(listWithAllowed, listWithForbidden);
+
+    const blue = new Blue({ nodeProvider });
+    const matcher = new NodeTypeMatcher(blue);
+
+    const targetTypeYaml = `itemsList:
+  type: List
+  itemType:
+    blueId: ${allowedItemId}`;
+    const targetType = blue.yamlToNode(targetTypeYaml);
+
+    expect(
+      matcher.matchesType(
+        nodeProvider.getNodeByName('Allowed Container'),
+        targetType
+      )
+    ).toBe(true);
+
+    expect(
+      matcher.matchesType(
+        nodeProvider.getNodeByName('Forbidden Container'),
+        targetType
+      )
+    ).toBe(false);
+  });
+
+  test('implicit List/Dictionary structural matching', () => {
+    const nodeProvider = new BasicNodeProvider();
+
+    // Implicit list node: has items, but no explicit type
+    const implicitListDoc = `name: ImplicitListNode
+items:
+  - value: 1
+  - value: 2`;
+    nodeProvider.addSingleDocs(implicitListDoc);
+
+    // Implicit dictionary node: has properties, but no explicit type
+    const implicitDictDoc = `name: ImplicitDictNode
+a:
+  value: 1
+b:
+  value: 2`;
+    nodeProvider.addSingleDocs(implicitDictDoc);
+
+    const blue = new Blue({ nodeProvider });
+    const matcher = new NodeTypeMatcher(blue);
+
+    const implicitListNode = nodeProvider.getNodeByName('ImplicitListNode');
+    const implicitDictNode = nodeProvider.getNodeByName('ImplicitDictNode');
+
+    // Target types expect core List/Dictionary using blueIds
+    const listTypeOnly = `type: List`;
+    const dictTypeOnly = `type: Dictionary`;
+
+    // Positive cases: implicit structures should satisfy corresponding core types
+    expect(
+      matcher.matchesType(implicitListNode, blue.yamlToNode(listTypeOnly))
+    ).toBe(true);
+    expect(
+      matcher.matchesType(implicitDictNode, blue.yamlToNode(dictTypeOnly))
+    ).toBe(true);
+
+    // Negative cross-cases
+    expect(
+      matcher.matchesType(implicitListNode, blue.yamlToNode(dictTypeOnly))
+    ).toBe(false);
+    expect(
+      matcher.matchesType(implicitDictNode, blue.yamlToNode(listTypeOnly))
+    ).toBe(false);
+
+    // Explicit wrong type should not match, even if structure resembles a list
+    const explicitTextButHasItems = `type: Text
+items:
+  - value: 1`;
+    expect(
+      matcher.matchesType(
+        implicitListNode,
+        blue.yamlToNode(explicitTextButHasItems)
+      )
+    ).toBe(false);
+  });
+
+  test('event-like json payloads: request as implicit list vs explicit List', () => {
+    const nodeProvider = new BasicNodeProvider();
+    const blue = new Blue({ nodeProvider });
+    const matcher = new NodeTypeMatcher(blue);
+
+    // Target type expects a List under message.request (use named core type)
+    const targetTypeYaml = `message:
+  request:
+    type: List`;
+    const targetType = blue.yamlToNode(targetTypeYaml);
+
+    // Event with explicit List wrapper
+    const explicitListEvent = blue.jsonValueToNode({
+      message: {
+        request: {
+          type: 'List',
+          items: [1, 2, 3],
+        },
+      },
+    });
+    expect(matcher.matchesType(explicitListEvent, targetType)).toBe(true);
+
+    // Event with implicit array (no explicit type)
+    const implicitArrayEvent = blue.jsonValueToNode({
+      message: {
+        request: [1, 2, 3],
+      },
+    });
+    expect(matcher.matchesType(implicitArrayEvent, targetType)).toBe(true);
+
+    // Negative: request is an object (dictionary), not a list
+    const wrongShapeEvent = blue.jsonValueToNode({
+      message: {
+        request: { a: 1, b: 2 },
+      },
+    });
+    expect(matcher.matchesType(wrongShapeEvent, targetType)).toBe(false);
+  });
+
+  test('dictionary valueType enforces property types', () => {
+    const nodeProvider = new BasicNodeProvider();
+
+    const activationState = `name: Activation State
+value: active`;
+    const wrongState = `name: Wrong State
+value: wrong`;
+    nodeProvider.addSingleDocs(activationState, wrongState);
+
+    const activationStateId = nodeProvider.getBlueIdByName('Activation State');
+    const wrongStateId = nodeProvider.getBlueIdByName('Wrong State');
+
+    const blue = new Blue({ nodeProvider });
+    const matcher = new NodeTypeMatcher(blue);
+
+    const targetTypeYaml = `participantsState:
+  type: Dictionary
+  valueType:
+    blueId: ${activationStateId}`;
+    const targetType = blue.yamlToNode(targetTypeYaml);
+
+    const createNodeWithValueBlueId = (valueBlueId: string) =>
+      new BlueNode('Container').setProperties({
+        participantsState: new BlueNode()
+          .setType(new BlueNode().setBlueId(DICTIONARY_TYPE_BLUE_ID))
+          .setProperties({
+            alice: new BlueNode()
+              .setBlueId(valueBlueId)
+              .setType(new BlueNode().setBlueId(valueBlueId)),
+          }),
+      });
+
+    const matchingNode = createNodeWithValueBlueId(activationStateId);
+
+    expect(matcher.matchesType(matchingNode, targetType)).toBe(true);
+
+    const mismatchedNode = createNodeWithValueBlueId(wrongStateId);
+    expect(matcher.matchesType(mismatchedNode, targetType)).toBe(false);
+  });
+
+  // Note: dictionary event-like case is covered in implicit structural tests above.
 });


### PR DESCRIPTION
…e itemType/valueType

- Add fast-path structural match when node lacks explicit type (List/Dictionary)
- Preserve original structure across extend/resolve to keep items/properties/ids/values
- Enforce List.itemType against all items and Dictionary.valueType against all properties
- Relax type/blueId checks appropriately when matching implicit structures
- Add tests for implicit structural matching, event-like payloads, and item/value type enforcement

test(document-processor): use array payload for message.request in bootstrap integration
- Switch from { type: 'List', items: [...] } to request: [...] to align with implicit list support

test(language): expand NodeTypeMatcher coverage for lists/dictionaries and event-like payloads