### PR TITLE
feat(language): add Blue.restoreInlineTypes to restore inline types

### DIFF
--- a/libs/language/src/lib/Blue.ts
+++ b/libs/language/src/lib/Blue.ts
@@ -32,6 +32,7 @@ import { MergingProcessor } from './merge/MergingProcessor';
 import { createDefaultMergingProcessor } from './merge';
 import { MergeReverser } from './utils/MergeReverser';
 import { CompositeLimits } from './utils/limits';
+import { InlineTypeRestorer } from './utils/InlineTypeRestorer';
 
 export type { BlueRepository } from './types/BlueRepository';
 
@@ -138,6 +139,21 @@ export class Blue {
   public reverse(node: BlueNode) {
     const reverser = new MergeReverser();
     return reverser.reverse(node);
+  }
+
+  /**
+   * Returns a copy of the provided node with any referenced types converted back to their
+   * inline representations (e.g. `Text`, `Dictionary`).
+   *
+   * The original node remains unchanged; the transformation relies on registered BlueIds and
+   * repository-backed definitions currently known to this {@link Blue} instance.
+   */
+  public restoreInlineTypes(node: BlueNode): BlueNode {
+    const restorer = new InlineTypeRestorer({
+      nodeProvider: this.nodeProvider,
+      blueIdsMappingGenerator: this.blueIdsMappingGenerator,
+    });
+    return restorer.restore(node);
   }
 
   public extend(node: BlueNode, limits: Limits) {

--- a/libs/language/src/lib/__tests__/Blue.inlineTypes.test.ts
+++ b/libs/language/src/lib/__tests__/Blue.inlineTypes.test.ts
@@ -1,0 +1,476 @@
+import { describe, it, expect } from 'vitest';
+import { Blue } from '../Blue';
+import { BlueIdCalculator } from '../utils/BlueIdCalculator';
+import type { BlueRepository } from '../types/BlueRepository';
+import { RepositoryBasedNodeProvider } from '../provider';
+import { TEXT_TYPE_BLUE_ID } from '../utils/Properties';
+
+describe('Blue.restoreInlineTypes', () => {
+  it('restores inline types for core mappings without mutating original node', () => {
+    const blue = new Blue();
+
+    const node = blue.jsonValueToNode({
+      field: {
+        type: 'Text',
+        value: 'sample',
+      },
+    });
+
+    const originalType = node.getProperties()?.field?.getType();
+    expect(originalType?.getBlueId()).toBe(TEXT_TYPE_BLUE_ID);
+    expect(originalType?.isInlineValue()).toBe(false);
+
+    const restored = blue.restoreInlineTypes(node);
+
+    // Original node should remain unchanged
+    expect(node.getProperties()?.field?.getType()?.getBlueId()).toBe(
+      TEXT_TYPE_BLUE_ID
+    );
+
+    const restoredType = restored.getProperties()?.field?.getType();
+    expect(restoredType?.isInlineValue()).toBe(true);
+    expect(restoredType?.getValue()).toBe('Text');
+    expect(restoredType?.getBlueId()).toBeUndefined();
+
+    expect(blue.nodeToJson(restored)).toMatchInlineSnapshot(`
+      {
+        "field": {
+          "type": {
+            "type": {
+              "blueId": "F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP",
+            },
+            "value": "Text",
+          },
+          "value": "sample",
+        },
+      }
+    `);
+  });
+
+  it('restores inline types using registered BlueIds', () => {
+    const blue = new Blue();
+
+    const linkDefinition = {
+      name: 'Link',
+      anchor: {
+        type: 'Text',
+      },
+    } as const;
+
+    const linkNode = blue.jsonValueToNode(linkDefinition);
+    const linkBlueId = BlueIdCalculator.calculateBlueIdSync(linkNode);
+    blue.registerBlueIds({ Link: linkBlueId });
+
+    const document = blue.jsonValueToNode({
+      reference: {
+        type: 'Link',
+      },
+    });
+
+    expect(document.getProperties()?.reference?.getType()?.getBlueId()).toBe(
+      linkBlueId
+    );
+
+    const restored = blue.restoreInlineTypes(document);
+    const restoredType = restored.getProperties()?.reference?.getType();
+
+    expect(restoredType?.isInlineValue()).toBe(true);
+    expect(restoredType?.getValue()).toBe('Link');
+
+    expect(blue.nodeToJson(restored)).toMatchInlineSnapshot(`
+      {
+        "reference": {
+          "type": {
+            "type": {
+              "blueId": "F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP",
+            },
+            "value": "Link",
+          },
+        },
+      }
+    `);
+  });
+
+  it('restores inline types on resolved nodes using repository data', () => {
+    const blue = new Blue();
+
+    const baseTypeDefinition = {
+      name: 'Base Type',
+      description: 'Reusable contract',
+      properties: {
+        label: {
+          type: 'Text',
+        },
+      },
+    } as const;
+
+    const baseTypeNode = blue.jsonValueToNode(baseTypeDefinition);
+    const baseTypeBlueId = BlueIdCalculator.calculateBlueIdSync(baseTypeNode);
+    blue.registerBlueIds({ 'Base Type': baseTypeBlueId });
+
+    const repository: BlueRepository = {
+      blueIds: { 'Base Type': baseTypeBlueId },
+      schemas: [],
+      contents: {
+        [baseTypeBlueId]: blue.nodeToJson(baseTypeNode),
+      },
+    };
+
+    blue.setNodeProvider(new RepositoryBasedNodeProvider([repository]));
+
+    const document = blue.jsonValueToNode({
+      contract: {
+        type: 'Base Type',
+        label: 'Test',
+      },
+    });
+
+    const resolved = blue.resolve(document);
+    const restoredResolved = blue.restoreInlineTypes(resolved);
+
+    const contractType = restoredResolved.getProperties()?.contract?.getType();
+    expect(contractType?.isInlineValue()).toBe(true);
+    expect(contractType?.getValue()).toBe('Base Type');
+
+    const labelType = restoredResolved
+      .getProperties()
+      ?.contract?.getProperties()
+      ?.label?.getType();
+    expect(labelType?.isInlineValue()).toBe(true);
+    expect(labelType?.getValue()).toBe('Text');
+
+    expect(blue.nodeToJson(restoredResolved)).toMatchInlineSnapshot(`
+      {
+        "contract": {
+          "label": {
+            "type": {
+              "type": {
+                "blueId": "F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP",
+              },
+              "value": "Text",
+            },
+            "value": "Test",
+          },
+          "properties": {
+            "label": {
+              "type": {
+                "type": {
+                  "blueId": "F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP",
+                },
+                "value": "Text",
+              },
+            },
+          },
+          "type": {
+            "type": {
+              "blueId": "F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP",
+            },
+            "value": "Base Type",
+          },
+        },
+      }
+    `);
+  });
+
+  it('restores inline types for resolved nodes with nested collections', () => {
+    const blue = new Blue();
+
+    const optionDefinition = {
+      name: 'Option',
+      label: {
+        type: 'Text',
+      },
+      code: {
+        type: 'Text',
+      },
+    } as const;
+
+    const optionNode = blue.jsonValueToNode(optionDefinition);
+    const optionBlueId = BlueIdCalculator.calculateBlueIdSync(optionNode);
+
+    const formDefinition = {
+      name: 'Form',
+      title: {
+        type: 'Text',
+      },
+      options: {
+        type: 'List',
+        itemType: {
+          blueId: optionBlueId,
+        },
+      },
+      attributes: {
+        type: 'Dictionary',
+        keyType: 'Text',
+        valueType: 'Text',
+      },
+    } as const;
+
+    const formNode = blue.jsonValueToNode(formDefinition);
+    const formBlueId = BlueIdCalculator.calculateBlueIdSync(formNode);
+
+    blue.registerBlueIds({ Option: optionBlueId, Form: formBlueId });
+
+    const repository: BlueRepository = {
+      blueIds: { Option: optionBlueId, Form: formBlueId },
+      schemas: [],
+      contents: {
+        [optionBlueId]: blue.nodeToJson(optionNode),
+        [formBlueId]: blue.nodeToJson(formNode),
+      },
+    };
+
+    blue.setNodeProvider(new RepositoryBasedNodeProvider([repository]));
+
+    const document = blue.jsonValueToNode({
+      name: 'Registration',
+      type: 'Form',
+      options: [
+        {
+          type: 'Option',
+          label: 'Marketing',
+          code: 'marketing',
+        },
+      ],
+      attributes: {
+        required: 'true',
+      },
+    });
+
+    const resolved = blue.resolve(document);
+    const restoredResolved = blue.restoreInlineTypes(resolved);
+
+    expect(resolved.getType()?.getBlueId()).toBe(formBlueId);
+    expect(resolved.getType()?.isInlineValue()).toBe(false);
+
+    const restoredType = restoredResolved.getType();
+    expect(restoredType?.isInlineValue()).toBe(true);
+    expect(restoredType?.getValue()).toBe('Form');
+
+    const optionsNode = restoredResolved.getProperties()?.options;
+    expect(optionsNode).toBeDefined();
+
+    const optionsItemType = optionsNode?.getItemType();
+    expect(optionsItemType?.isInlineValue()).toBe(true);
+    expect(optionsItemType?.getValue()).toBe('Option');
+
+    const firstOptionType = optionsNode?.getItems()?.[0]?.getType();
+    expect(firstOptionType?.isInlineValue()).toBe(true);
+    expect(firstOptionType?.getValue()).toBe('Option');
+
+    const attributesNode = restoredResolved.getProperties()?.attributes;
+    expect(attributesNode).toBeDefined();
+
+    const keyType = attributesNode?.getKeyType();
+    expect(keyType?.isInlineValue()).toBe(true);
+    expect(keyType?.getValue()).toBe('Text');
+
+    const valueType = attributesNode?.getValueType();
+    expect(valueType?.isInlineValue()).toBe(true);
+    expect(valueType?.getValue()).toBe('Text');
+
+    const requiredEntryType = attributesNode
+      ?.getProperties()
+      ?.required?.getType();
+    expect(requiredEntryType?.isInlineValue()).toBe(true);
+    expect(requiredEntryType?.getValue()).toBe('Text');
+
+    expect(blue.nodeToJson(restoredResolved, 'official'))
+      .toMatchInlineSnapshot(`
+      {
+        "attributes": {
+          "keyType": {
+            "type": {
+              "blueId": "F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP",
+            },
+            "value": "Text",
+          },
+          "required": {
+            "type": {
+              "type": {
+                "blueId": "F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP",
+              },
+              "value": "Text",
+            },
+            "value": "true",
+          },
+          "type": {
+            "type": {
+              "blueId": "F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP",
+            },
+            "value": "Dictionary",
+          },
+          "valueType": {
+            "type": {
+              "blueId": "F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP",
+            },
+            "value": "Text",
+          },
+        },
+        "name": "Registration",
+        "options": {
+          "itemType": {
+            "type": {
+              "blueId": "F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP",
+            },
+            "value": "Option",
+          },
+          "items": [
+            {
+              "code": {
+                "type": {
+                  "type": {
+                    "blueId": "F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP",
+                  },
+                  "value": "Text",
+                },
+                "value": "marketing",
+              },
+              "label": {
+                "type": {
+                  "type": {
+                    "blueId": "F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP",
+                  },
+                  "value": "Text",
+                },
+                "value": "Marketing",
+              },
+              "type": {
+                "type": {
+                  "blueId": "F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP",
+                },
+                "value": "Option",
+              },
+            },
+          ],
+          "type": {
+            "type": {
+              "blueId": "F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP",
+            },
+            "value": "List",
+          },
+        },
+        "title": {
+          "type": {
+            "type": {
+              "blueId": "F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP",
+            },
+            "value": "Text",
+          },
+        },
+        "type": {
+          "type": {
+            "blueId": "F92yo19rCcbBoBSpUA5LRxpfDejJDAaP1PRxxbWAraVP",
+          },
+          "value": "Form",
+        },
+      }
+    `);
+
+    expect(blue.nodeToJson(restoredResolved, 'simple')).toMatchInlineSnapshot(`
+      {
+        "attributes": {
+          "keyType": "Text",
+          "required": "true",
+          "type": "Dictionary",
+          "valueType": "Text",
+        },
+        "name": "Registration",
+        "options": [
+          {
+            "code": "marketing",
+            "label": "Marketing",
+            "type": "Option",
+          },
+        ],
+        "title": {
+          "type": "Text",
+        },
+        "type": "Form",
+      }
+    `);
+  });
+
+  it('keeps inherited values after restoring inline types', () => {
+    const blue = new Blue();
+
+    const baseDefinition = {
+      name: 'Base Preferences',
+      enabled: {
+        type: 'Boolean',
+        value: true,
+      },
+      retries: {
+        type: 'Integer',
+        value: 3,
+      },
+    } as const;
+
+    const derivedDefinition = {
+      name: 'Derived Preferences',
+      type: 'Base Preferences',
+      notes: {
+        type: 'Text',
+      },
+    } as const;
+
+    const baseNode = blue.jsonValueToNode(baseDefinition);
+    const baseBlueId = BlueIdCalculator.calculateBlueIdSync(baseNode);
+    blue.registerBlueIds({ 'Base Preferences': baseBlueId });
+
+    const derivedNode = blue.jsonValueToNode(derivedDefinition);
+    const derivedBlueId = BlueIdCalculator.calculateBlueIdSync(derivedNode);
+    blue.registerBlueIds({ 'Derived Preferences': derivedBlueId });
+
+    const repository: BlueRepository = {
+      blueIds: {
+        'Base Preferences': baseBlueId,
+        'Derived Preferences': derivedBlueId,
+      },
+      schemas: [],
+      contents: {
+        [baseBlueId]: blue.nodeToJson(baseNode),
+        [derivedBlueId]: blue.nodeToJson(derivedNode),
+      },
+    };
+
+    blue.setNodeProvider(new RepositoryBasedNodeProvider([repository]));
+
+    const document = blue.jsonValueToNode({
+      name: 'Runtime Preferences',
+      type: 'Derived Preferences',
+      notes: 'Customized behaviour',
+    });
+
+    const resolved = blue.resolve(document);
+    const restoredResolved = blue.restoreInlineTypes(resolved);
+
+    const resolvedType = restoredResolved.getType();
+    expect(resolvedType?.isInlineValue()).toBe(true);
+    expect(resolvedType?.getValue()).toBe('Derived Preferences');
+
+    const enabledNode = restoredResolved.getProperties()?.enabled;
+    expect(enabledNode?.getValue()).toBe(true);
+    expect(enabledNode?.getType()?.isInlineValue()).toBe(true);
+    expect(enabledNode?.getType()?.getValue()).toBe('Boolean');
+
+    const retriesNode = restoredResolved.getProperties()?.retries;
+    expect(retriesNode?.getValue()?.toString()).toBe('3');
+    expect(retriesNode?.getType()?.isInlineValue()).toBe(true);
+    expect(retriesNode?.getType()?.getValue()).toBe('Integer');
+
+    const notesNode = restoredResolved.getProperties()?.notes;
+    expect(notesNode?.getType()?.isInlineValue()).toBe(true);
+    expect(notesNode?.getType()?.getValue()).toBe('Text');
+
+    expect(blue.nodeToJson(restoredResolved, 'simple')).toMatchInlineSnapshot(`
+      {
+        "enabled": true,
+        "name": "Runtime Preferences",
+        "notes": "Customized behaviour",
+        "retries": 3,
+        "type": "Derived Preferences",
+      }
+    `);
+  });
+});

--- a/libs/language/src/lib/utils/InlineTypeRestorer.ts
+++ b/libs/language/src/lib/utils/InlineTypeRestorer.ts
@@ -1,0 +1,124 @@
+import { BlueNode } from '../model';
+import { NodeProvider } from '../NodeProvider';
+import { NodeTransformer } from './NodeTransformer';
+import { CORE_TYPE_BLUE_ID_TO_NAME_MAP } from './Properties';
+import { BlueIdsMappingGenerator } from '../preprocess/utils/BlueIdsMappingGenerator';
+
+export interface InlineTypeRestorerOptions {
+  nodeProvider: NodeProvider;
+  blueIdsMappingGenerator: BlueIdsMappingGenerator;
+}
+
+/**
+ * Restores inline type declarations by converting BlueId references back to their inline values.
+ */
+export class InlineTypeRestorer {
+  private readonly nodeProvider: NodeProvider;
+  private readonly blueIdToInlineValue: Map<string, string> = new Map();
+
+  constructor(options: InlineTypeRestorerOptions) {
+    const { nodeProvider, blueIdsMappingGenerator } = options;
+    this.nodeProvider = nodeProvider;
+
+    // Seed with core Blue type mappings so we always have defaults available.
+    Object.entries(CORE_TYPE_BLUE_ID_TO_NAME_MAP).forEach(([blueId, name]) => {
+      this.blueIdToInlineValue.set(blueId, name);
+    });
+
+    // Add dynamically registered mappings (repositories, manual registrations, etc.).
+    const allRegisteredBlueIds = blueIdsMappingGenerator.getAllBlueIds();
+    Object.entries(allRegisteredBlueIds).forEach(([inlineName, blueId]) => {
+      if (!this.blueIdToInlineValue.has(blueId)) {
+        this.blueIdToInlineValue.set(blueId, inlineName);
+      }
+    });
+  }
+
+  /**
+   * Returns a new BlueNode where all type references are restored to inline values when possible.
+   */
+  public restore(node: BlueNode): BlueNode {
+    return NodeTransformer.transform(node, (current) => this.restoreNode(current));
+  }
+
+  private restoreNode(node: BlueNode): BlueNode {
+    this.restoreTypeField(
+      node,
+      () => node.getType(),
+      (value) => node.setType(value)
+    );
+
+    this.restoreTypeField(
+      node,
+      () => node.getItemType(),
+      (value) => node.setItemType(value)
+    );
+
+    this.restoreTypeField(
+      node,
+      () => node.getKeyType(),
+      (value) => node.setKeyType(value)
+    );
+
+    this.restoreTypeField(
+      node,
+      () => node.getValueType(),
+      (value) => node.setValueType(value)
+    );
+
+    return node;
+  }
+
+  private restoreTypeField(
+    node: BlueNode,
+    getter: () => BlueNode | undefined,
+    setter: (value: BlueNode | undefined) => void
+  ): void {
+    const typeNode = getter();
+    if (!typeNode) {
+      return;
+    }
+
+    if (typeNode.isInlineValue() && typeNode.getValue() !== undefined) {
+      return;
+    }
+
+    const blueId = typeNode.getBlueId();
+    if (!blueId) {
+      return;
+    }
+
+    const inlineValue = this.resolveInlineValue(blueId, typeNode);
+    if (!inlineValue) {
+      return;
+    }
+
+    const inlineNode = new BlueNode().setValue(inlineValue).setInlineValue(true);
+    setter(inlineNode);
+  }
+
+  private resolveInlineValue(
+    blueId: string,
+    contextNode: BlueNode
+  ): string | undefined {
+    const cached = this.blueIdToInlineValue.get(blueId);
+    if (cached) {
+      return cached;
+    }
+
+    const contextName = contextNode.getName();
+    if (contextName) {
+      this.blueIdToInlineValue.set(blueId, contextName);
+      return contextName;
+    }
+
+    const resolved = this.nodeProvider.fetchFirstByBlueId(blueId);
+    const resolvedName = resolved?.getName();
+    if (resolvedName) {
+      this.blueIdToInlineValue.set(blueId, resolvedName);
+      return resolvedName;
+    }
+
+    return undefined;
+  }
+}


### PR DESCRIPTION
- Add InlineTypeRestorer to convert BlueId-based type refs back to inline values (e.g., Text, Dictionary), seeded with core mappings and extended by registered BlueIds and repository-backed definitions.
- Expose public API Blue.restoreInlineTypes(node) that returns a transformed copy without mutating the original node.
- Handle type, itemType, keyType, and valueType across resolved nodes, nested collections, and inherited values.
- Add comprehensive tests in libs/language/src/lib/__tests__/Blue.inlineTypes.test.ts covering core mappings, registered BlueIds, repository resolution, nested collections, immutability, and inheritance.
- Add JSDoc to the new API in Blue.ts.