### PR TITLE
[codex] feat(document-processor): support actor policy contract

### DIFF
--- a/libs/document-processor/src/api/__tests__/document-processor.test.ts
+++ b/libs/document-processor/src/api/__tests__/document-processor.test.ts
@@ -150,11 +150,30 @@ contracts:
             blueId: conversationBlueIds['Conversation/Contracts Change Policy'],
           },
         },
+        actorPolicy: {
+          type: {
+            blueId: conversationBlueIds['Conversation/Actor Policy'],
+          },
+          operations: {
+            authorizeFunds: {
+              requiresActor: 'principal',
+              requiresSource: 'browserSession',
+            },
+          },
+        },
       },
     });
 
     const markers = processor.markersFor(original, '/');
     expect(markers.has('section')).toBe(true);
     expect(markers.has('policy')).toBe(true);
+    expect(markers.get('actorPolicy')).toMatchObject({
+      operations: {
+        authorizeFunds: {
+          requiresActor: 'principal',
+          requiresSource: 'browserSession',
+        },
+      },
+    });
   });
 });

--- a/libs/document-processor/src/engine/__tests__/contract-loader.test.ts
+++ b/libs/document-processor/src/engine/__tests__/contract-loader.test.ts
@@ -11,7 +11,11 @@ import type { HandlerContract } from '../../model/index.js';
 import type { HandlerProcessor } from '../../registry/index.js';
 import { MustUnderstandFailure } from '../must-understand-failure.js';
 import { ProcessorFatalError } from '../processor-fatal-error.js';
-import { blueIds, createBlue } from '../../test-support/blue.js';
+import {
+  blueIds,
+  createBlue,
+  createBlueWithDerivedTypes,
+} from '../../test-support/blue.js';
 
 const blueIdDocumentUpdate = blueIds['Core/Document Update Channel'];
 const blueIdInitialization = blueIds['Core/Processing Initialized Marker'];
@@ -30,6 +34,13 @@ function buildScopeNode(
   contracts: Record<string, unknown>,
 ): BlueNode {
   return blue.jsonValueToNode({ contracts });
+}
+
+function derivedActorPolicyTypeYaml(name: string): string {
+  return `name: ${name}
+type:
+  blueId: ${blueIdActorPolicy}
+`;
 }
 
 describe('ContractLoader', () => {
@@ -188,6 +199,41 @@ describe('ContractLoader', () => {
     });
   });
 
+  it('loads derived Actor Policy markers with parsed operations', () => {
+    const { blue, derivedBlueIds } = createBlueWithDerivedTypes([
+      {
+        name: 'Derived Actor Policy',
+        yaml: derivedActorPolicyTypeYaml('Derived Actor Policy'),
+      },
+    ]);
+    const registry = ContractProcessorRegistryBuilder.create()
+      .registerDefaults()
+      .build();
+    const loader = new ContractLoader(registry, blue);
+    const scopeNode = buildScopeNode(blue, {
+      actorPolicy: {
+        type: { blueId: derivedBlueIds['Derived Actor Policy'] },
+        operations: {
+          authorizeFunds: {
+            requiresActor: 'principal',
+            requiresSource: 'browserSession',
+          },
+        },
+      },
+    });
+
+    const bundle = loader.load(scopeNode, '/');
+
+    expect(bundle.marker('actorPolicy')).toMatchObject({
+      operations: {
+        authorizeFunds: {
+          requiresActor: 'principal',
+          requiresSource: 'browserSession',
+        },
+      },
+    });
+  });
+
   it('rejects duplicate Actor Policy markers in one scope', () => {
     const blue = createBlue();
     const registry = ContractProcessorRegistryBuilder.create()
@@ -204,6 +250,60 @@ describe('ContractLoader', () => {
     });
 
     expect(() => loader.load(scopeNode, '/')).toThrowError(ProcessorFatalError);
+  });
+
+  it('rejects base and derived Actor Policy markers in one scope', () => {
+    const { blue, derivedBlueIds } = createBlueWithDerivedTypes([
+      {
+        name: 'Derived Actor Policy',
+        yaml: derivedActorPolicyTypeYaml('Derived Actor Policy'),
+      },
+    ]);
+    const registry = ContractProcessorRegistryBuilder.create()
+      .registerDefaults()
+      .build();
+    const loader = new ContractLoader(registry, blue);
+    const scopeNode = buildScopeNode(blue, {
+      actorPolicyBase: {
+        type: { blueId: blueIdActorPolicy },
+      },
+      actorPolicyDerived: {
+        type: { blueId: derivedBlueIds['Derived Actor Policy'] },
+      },
+    });
+
+    expect(() => loader.load(scopeNode, '/')).toThrowError(
+      /Multiple Actor Policy markers declared in the same scope/,
+    );
+  });
+
+  it('rejects multiple derived Actor Policy markers in one scope', () => {
+    const { blue, derivedBlueIds } = createBlueWithDerivedTypes([
+      {
+        name: 'Derived Actor Policy A',
+        yaml: derivedActorPolicyTypeYaml('Derived Actor Policy A'),
+      },
+      {
+        name: 'Derived Actor Policy B',
+        yaml: derivedActorPolicyTypeYaml('Derived Actor Policy B'),
+      },
+    ]);
+    const registry = ContractProcessorRegistryBuilder.create()
+      .registerDefaults()
+      .build();
+    const loader = new ContractLoader(registry, blue);
+    const scopeNode = buildScopeNode(blue, {
+      actorPolicyA: {
+        type: { blueId: derivedBlueIds['Derived Actor Policy A'] },
+      },
+      actorPolicyB: {
+        type: { blueId: derivedBlueIds['Derived Actor Policy B'] },
+      },
+    });
+
+    expect(() => loader.load(scopeNode, '/')).toThrowError(
+      /Multiple Actor Policy markers declared in the same scope/,
+    );
   });
 
   it('rejects Actor Policy markers with unsupported rule literals', () => {

--- a/libs/document-processor/src/engine/__tests__/contract-loader.test.ts
+++ b/libs/document-processor/src/engine/__tests__/contract-loader.test.ts
@@ -19,6 +19,7 @@ const blueIdProcessEmbedded = blueIds['Core/Process Embedded'];
 const blueIdCheckpoint = blueIds['Core/Channel Event Checkpoint'];
 const blueIdCompositeTimeline =
   conversationBlueIds['Conversation/Composite Timeline Channel'];
+const blueIdActorPolicy = conversationBlueIds['Conversation/Actor Policy'];
 const blueIdDocumentSection =
   conversationBlueIds['Conversation/Document Section'];
 const blueIdContractsChangePolicy =
@@ -155,6 +156,74 @@ describe('ContractLoader', () => {
 
     expect(bundle.marker('section')).toBeDefined();
     expect(bundle.marker('policy')).toBeDefined();
+  });
+
+  it('loads Actor Policy markers with parsed operations', () => {
+    const blue = createBlue();
+    const registry = ContractProcessorRegistryBuilder.create()
+      .registerDefaults()
+      .build();
+    const loader = new ContractLoader(registry, blue);
+    const scopeNode = buildScopeNode(blue, {
+      actorPolicy: {
+        type: { blueId: blueIdActorPolicy },
+        operations: {
+          authorizeFunds: {
+            requiresActor: 'principal',
+            requiresSource: 'browserSession',
+          },
+        },
+      },
+    });
+
+    const bundle = loader.load(scopeNode, '/');
+
+    expect(bundle.marker('actorPolicy')).toMatchObject({
+      operations: {
+        authorizeFunds: {
+          requiresActor: 'principal',
+          requiresSource: 'browserSession',
+        },
+      },
+    });
+  });
+
+  it('rejects duplicate Actor Policy markers in one scope', () => {
+    const blue = createBlue();
+    const registry = ContractProcessorRegistryBuilder.create()
+      .registerDefaults()
+      .build();
+    const loader = new ContractLoader(registry, blue);
+    const scopeNode = buildScopeNode(blue, {
+      actorPolicyA: {
+        type: { blueId: blueIdActorPolicy },
+      },
+      actorPolicyB: {
+        type: { blueId: blueIdActorPolicy },
+      },
+    });
+
+    expect(() => loader.load(scopeNode, '/')).toThrowError(ProcessorFatalError);
+  });
+
+  it('rejects Actor Policy markers with unsupported rule literals', () => {
+    const blue = createBlue();
+    const registry = ContractProcessorRegistryBuilder.create()
+      .registerDefaults()
+      .build();
+    const loader = new ContractLoader(registry, blue);
+    const scopeNode = buildScopeNode(blue, {
+      actorPolicy: {
+        type: { blueId: blueIdActorPolicy },
+        operations: {
+          authorizeFunds: {
+            requiresActor: 'robot',
+          },
+        },
+      },
+    });
+
+    expect(() => loader.load(scopeNode, '/')).toThrowError(ProcessorFatalError);
   });
 
   it('loads custom handler contracts using registry schema', () => {

--- a/libs/document-processor/src/engine/contract-bundle.ts
+++ b/libs/document-processor/src/engine/contract-bundle.ts
@@ -1,5 +1,6 @@
 import { BlueNode } from '@blue-labs/language';
 import { blueIds } from '@blue-repository/types/packages/core/blue-ids';
+import { blueIds as conversationBlueIds } from '@blue-repository/types/packages/conversation/blue-ids';
 
 import { KEY_CHECKPOINT } from '../constants/processor-contract-constants.js';
 import type {
@@ -21,6 +22,7 @@ type StoredHandler = HandlerContractEntry;
 
 const CHANNEL_EVENT_CHECKPOINT_BLUE_ID =
   blueIds['Core/Channel Event Checkpoint'];
+const ACTOR_POLICY_BLUE_ID = conversationBlueIds['Conversation/Actor Policy'];
 
 function contractOrder(contract: { readonly order?: number | null }): number {
   return typeof contract.order === 'number' ? contract.order : 0;
@@ -287,6 +289,16 @@ export class ContractBundleBuilder {
         );
       }
       this.checkpointDeclared = true;
+    }
+    if (
+      blueId === ACTOR_POLICY_BLUE_ID &&
+      Array.from(this.markerStore.values()).some(
+        (entry) => entry.blueId === ACTOR_POLICY_BLUE_ID,
+      )
+    ) {
+      throw new Error(
+        'Multiple Actor Policy markers detected in same contracts map',
+      );
     }
     this.markerStore.set(key, { key, contract, blueId });
     return this;

--- a/libs/document-processor/src/engine/contract-bundle.ts
+++ b/libs/document-processor/src/engine/contract-bundle.ts
@@ -1,6 +1,5 @@
 import { BlueNode } from '@blue-labs/language';
 import { blueIds } from '@blue-repository/types/packages/core/blue-ids';
-import { blueIds as conversationBlueIds } from '@blue-repository/types/packages/conversation/blue-ids';
 
 import { KEY_CHECKPOINT } from '../constants/processor-contract-constants.js';
 import type {
@@ -22,7 +21,6 @@ type StoredHandler = HandlerContractEntry;
 
 const CHANNEL_EVENT_CHECKPOINT_BLUE_ID =
   blueIds['Core/Channel Event Checkpoint'];
-const ACTOR_POLICY_BLUE_ID = conversationBlueIds['Conversation/Actor Policy'];
 
 function contractOrder(contract: { readonly order?: number | null }): number {
   return typeof contract.order === 'number' ? contract.order : 0;
@@ -289,16 +287,6 @@ export class ContractBundleBuilder {
         );
       }
       this.checkpointDeclared = true;
-    }
-    if (
-      blueId === ACTOR_POLICY_BLUE_ID &&
-      Array.from(this.markerStore.values()).some(
-        (entry) => entry.blueId === ACTOR_POLICY_BLUE_ID,
-      )
-    ) {
-      throw new Error(
-        'Multiple Actor Policy markers detected in same contracts map',
-      );
     }
     this.markerStore.set(key, { key, contract, blueId });
     return this;

--- a/libs/document-processor/src/engine/contract-loader.ts
+++ b/libs/document-processor/src/engine/contract-loader.ts
@@ -194,7 +194,14 @@ export class ContractLoader {
       BUILTIN_MARKER_SCHEMAS,
     );
     if (builtinMarkerSchema) {
-      this.handleMarker(builder, key, node, builtinMarkerSchema, blueId);
+      this.handleMarker(
+        builder,
+        key,
+        node,
+        builtinMarkerSchema,
+        blueId,
+        scopeContracts,
+      );
       return;
     }
 
@@ -255,6 +262,7 @@ export class ContractLoader {
         node,
         markerProcessor.schema as ZodType<MarkerContract>,
         blueId,
+        scopeContracts,
       );
       return;
     }
@@ -415,14 +423,13 @@ export class ContractLoader {
     node: BlueNode,
     schema: ZodType<MarkerContract>,
     blueId: string,
+    scopeContracts: ScopeContractsIndex,
   ): void {
     try {
-      if (
-        this.blue.isTypeOfBlueId(
-          node,
-          conversationBlueIds['Conversation/Actor Policy'],
-        )
-      ) {
+      const actorPolicyBlueId =
+        conversationBlueIds['Conversation/Actor Policy'];
+      if (this.blue.isTypeOfBlueId(node, actorPolicyBlueId)) {
+        this.assertSingleActorPolicyMarker(key, scopeContracts, blueId);
         validateActorPolicyNode(node);
       }
       const marker = this.blue.nodeToSchemaOutput(
@@ -431,6 +438,12 @@ export class ContractLoader {
       ) as MarkerContract;
       builder.addMarker(key, marker, blueId);
     } catch (error) {
+      if (
+        error instanceof ProcessorFatalError ||
+        error instanceof MustUnderstandFailure
+      ) {
+        throw error;
+      }
       if (isZodError(error)) {
         throw new ProcessorFatalError(
           'Failed to parse marker contract',
@@ -450,6 +463,33 @@ export class ContractLoader {
         ProcessorErrors.illegalState(reason),
       );
     }
+  }
+
+  private assertSingleActorPolicyMarker(
+    key: string,
+    scopeContracts: ScopeContractsIndex,
+    blueId: string,
+  ): void {
+    const actorPolicyBlueId = conversationBlueIds['Conversation/Actor Policy'];
+    const conflictingEntry = Array.from(scopeContracts.entries()).find(
+      ([entryKey, entry]) =>
+        entryKey !== key &&
+        this.blue.isTypeOfBlueId(entry.node, actorPolicyBlueId),
+    );
+
+    if (!conflictingEntry) {
+      return;
+    }
+
+    const [conflictingKey] = conflictingEntry;
+    throw new ProcessorFatalError(
+      `Multiple Actor Policy markers declared in the same scope: '${key}' conflicts with '${conflictingKey}'`,
+      ProcessorErrors.invalidContract(
+        blueId,
+        'Multiple Actor Policy markers declared in the same scope',
+        `/contracts/${key}`,
+      ),
+    );
   }
 
   private buildScopeContractsIndex(

--- a/libs/document-processor/src/engine/contract-loader.ts
+++ b/libs/document-processor/src/engine/contract-loader.ts
@@ -18,6 +18,7 @@ import {
   myosParticipantsOrchestrationMarkerSchema,
   myosSessionInteractionMarkerSchema,
   myosWorkerAgencyMarkerSchema,
+  validateActorPolicyNode,
 } from '../model/index.js';
 import { isProcessorManagedChannelBlueId } from '../constants/processor-contract-constants.js';
 import { ContractBundle, ContractBundleBuilder } from './contract-bundle.js';
@@ -416,6 +417,14 @@ export class ContractLoader {
     blueId: string,
   ): void {
     try {
+      if (
+        this.blue.isTypeOfBlueId(
+          node,
+          conversationBlueIds['Conversation/Actor Policy'],
+        )
+      ) {
+        validateActorPolicyNode(node);
+      }
       const marker = this.blue.nodeToSchemaOutput(
         node,
         schema,

--- a/libs/document-processor/src/model/markers/actor-policy.ts
+++ b/libs/document-processor/src/model/markers/actor-policy.ts
@@ -1,0 +1,99 @@
+import { BlueNode } from '@blue-labs/language';
+import { z } from 'zod';
+
+import { ActorPolicySchema as RepositoryActorPolicySchema } from '@blue-repository/types/packages/conversation/schemas/ActorPolicy';
+
+import { markerContractBaseSchema } from '../shared/index.js';
+
+const ACTOR_POLICY_ACTOR_VALUES = ['principal', 'agent', 'any'] as const;
+const ACTOR_POLICY_SOURCE_VALUES = [
+  'browserSession',
+  'apiCall',
+  'documentRequest',
+] as const;
+
+const actorPolicyActorValueSchema = z.enum(ACTOR_POLICY_ACTOR_VALUES);
+const actorPolicySourceValueSchema = z.enum(ACTOR_POLICY_SOURCE_VALUES);
+
+export const actorPolicyRuleSchema = z.object({
+  excludeSource: actorPolicySourceValueSchema.optional(),
+  requiresActor: actorPolicyActorValueSchema.optional(),
+  requiresSource: actorPolicySourceValueSchema.optional(),
+});
+
+export const actorPolicyMarkerSchema = RepositoryActorPolicySchema.merge(
+  markerContractBaseSchema,
+).extend({
+  operations: z.record(z.string(), actorPolicyRuleSchema).optional(),
+});
+
+export type ActorPolicyRule = z.infer<typeof actorPolicyRuleSchema>;
+export type ActorPolicyMarker = z.infer<typeof actorPolicyMarkerSchema>;
+
+const VALID_ACTOR_POLICY_ACTORS = new Set<string>(ACTOR_POLICY_ACTOR_VALUES);
+const VALID_ACTOR_POLICY_SOURCES = new Set<string>(ACTOR_POLICY_SOURCE_VALUES);
+
+export function validateActorPolicyNode(node: BlueNode): void {
+  const operationsNode = node.getProperties()?.operations;
+  if (!(operationsNode instanceof BlueNode)) {
+    return;
+  }
+
+  const operationEntries = operationsNode.getProperties();
+  if (!operationEntries) {
+    return;
+  }
+
+  for (const [operationKey, ruleNode] of Object.entries(operationEntries)) {
+    if (!(ruleNode instanceof BlueNode)) {
+      continue;
+    }
+    const ruleEntries = ruleNode.getProperties();
+    if (!ruleEntries) {
+      continue;
+    }
+
+    validateActorPolicyField(
+      operationKey,
+      'requiresActor',
+      ruleEntries.requiresActor,
+      VALID_ACTOR_POLICY_ACTORS,
+    );
+    validateActorPolicyField(
+      operationKey,
+      'requiresSource',
+      ruleEntries.requiresSource,
+      VALID_ACTOR_POLICY_SOURCES,
+    );
+    validateActorPolicyField(
+      operationKey,
+      'excludeSource',
+      ruleEntries.excludeSource,
+      VALID_ACTOR_POLICY_SOURCES,
+    );
+  }
+}
+
+function validateActorPolicyField(
+  operationKey: string,
+  fieldName: 'excludeSource' | 'requiresActor' | 'requiresSource',
+  node: BlueNode | undefined,
+  allowedValues: ReadonlySet<string>,
+): void {
+  if (!(node instanceof BlueNode)) {
+    return;
+  }
+
+  const rawValue = node.getValue();
+  if (rawValue == null) {
+    return;
+  }
+
+  if (typeof rawValue !== 'string' || !allowedValues.has(rawValue)) {
+    throw new Error(
+      `Actor Policy operation '${operationKey}' declares unsupported ${fieldName} '${String(
+        rawValue,
+      )}'`,
+    );
+  }
+}

--- a/libs/document-processor/src/model/markers/index.ts
+++ b/libs/document-processor/src/model/markers/index.ts
@@ -1,3 +1,4 @@
+export * from './actor-policy.js';
 export * from './channel-event-checkpoint.js';
 export * from './initialization-marker.js';
 export * from './process-embedded.js';

--- a/libs/document-processor/src/model/types.ts
+++ b/libs/document-processor/src/model/types.ts
@@ -2,6 +2,7 @@ import type { ChannelContractBase } from './shared/channel-contract-base.js';
 import type { HandlerContractBase } from './shared/handler-contract-base.js';
 import type { MarkerContractBase } from './shared/marker-contract-base.js';
 import type {
+  ActorPolicyMarker,
   ChannelEventCheckpoint,
   InitializationMarker,
   ProcessEmbeddedMarker,
@@ -33,6 +34,7 @@ export type GenericChannelContract = ChannelContractBase &
   Record<string, unknown>;
 
 export type MarkerContract =
+  | ActorPolicyMarker
   | ProcessEmbeddedMarker
   | InitializationMarker
   | ProcessingTerminatedMarker

--- a/libs/document-processor/src/registry/__tests__/sequential-workflow-operation-processor.test.ts
+++ b/libs/document-processor/src/registry/__tests__/sequential-workflow-operation-processor.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { BlueNode } from '@blue-labs/language';
+import { BlueNode, type Blue } from '@blue-labs/language';
 
-import { createBlue } from '../../test-support/blue.js';
+import {
+  createBlue,
+  createBlueWithDerivedTypes,
+} from '../../test-support/blue.js';
 import {
   buildProcessor,
   expectOk,
@@ -40,7 +43,17 @@ function indentBlock(block: string, spaces: number): string {
 const DEFAULT_STEP_EXPRESSION =
   "${event.message.request + document('/counter')}";
 
-function buildOperationDocument(options?: DocumentBuildOptions): BlueNode {
+function derivedActorPolicyTypeYaml(name: string): string {
+  return `name: ${name}
+type:
+  blueId: ${conversationBlueIds['Conversation/Actor Policy']}
+`;
+}
+
+function buildOperationDocument(
+  options?: DocumentBuildOptions,
+  blueInstance: Blue = blue,
+): BlueNode {
   const {
     actorPolicyYaml,
     operationChannel,
@@ -95,17 +108,20 @@ ${handlerEventSection}    steps:
         changeset:
 ${indentBlock(resolvedChangesetYaml, 10)}
 `;
-  return blue.yamlToNode(yaml);
+  return blueInstance.yamlToNode(yaml);
 }
 
-function operationRequestEvent(options?: {
-  request?: unknown;
-  allowNewerVersion?: boolean;
-  actor?: unknown;
-  documentBlueId?: string;
-  operation?: string;
-  source?: unknown;
-}): BlueNode {
+function operationRequestEvent(
+  options?: {
+    request?: unknown;
+    allowNewerVersion?: boolean;
+    actor?: unknown;
+    documentBlueId?: string;
+    operation?: string;
+    source?: unknown;
+  },
+  blueInstance: Blue = blue,
+): BlueNode {
   const {
     request = 1,
     allowNewerVersion = true,
@@ -136,7 +152,7 @@ function operationRequestEvent(options?: {
     entry.source = source;
   }
   entry.message = message;
-  return blue.jsonValueToNode(entry);
+  return blueInstance.jsonValueToNode(entry);
 }
 
 function storedDocumentBlueId(document: BlueNode): string {
@@ -199,6 +215,54 @@ operations:
         uiSessionNonce: 'sess-1',
       },
     });
+
+    const result = await expectOk(
+      processor.processDocument(init.document.clone(), event),
+    );
+
+    expect(numericValue(property(result.document, 'counter'))).toBe(2);
+  });
+
+  it('applies derived Actor Policy rules for principal actors in browser sessions', async () => {
+    const { blue: derivedBlue, derivedBlueIds } = createBlueWithDerivedTypes([
+      {
+        name: 'Derived Actor Policy',
+        yaml: derivedActorPolicyTypeYaml('Derived Actor Policy'),
+      },
+    ]);
+    const processor = buildProcessor(derivedBlue);
+    const init = await expectOk(
+      processor.initializeDocument(
+        buildOperationDocument(
+          {
+            actorPolicyYaml: `type:
+  blueId: ${derivedBlueIds['Derived Actor Policy']}
+operations:
+  ${OPERATION_KEY}:
+    requiresActor: principal
+    requiresSource: browserSession`,
+          },
+          derivedBlue,
+        ),
+      ),
+    );
+    const storedBlueId = storedDocumentBlueId(init.document);
+    const event = operationRequestEvent(
+      {
+        request: 2,
+        allowNewerVersion: false,
+        documentBlueId: storedBlueId,
+        actor: {
+          type: 'MyOS/MyOS Principal Actor',
+          accountId: 'alice-id',
+        },
+        source: {
+          type: 'Conversation/Browser Session',
+          uiSessionNonce: 'sess-1',
+        },
+      },
+      derivedBlue,
+    );
 
     const result = await expectOk(
       processor.processDocument(init.document.clone(), event),

--- a/libs/document-processor/src/registry/__tests__/sequential-workflow-operation-processor.test.ts
+++ b/libs/document-processor/src/registry/__tests__/sequential-workflow-operation-processor.test.ts
@@ -18,6 +18,7 @@ const TIMELINE_ID = 'owner-42';
 const OPERATION_KEY = 'increment';
 
 type DocumentBuildOptions = {
+  actorPolicyYaml?: string;
   operationChannel?: string | null;
   requestTypeYaml?: string;
   handlerEventYaml?: string;
@@ -41,6 +42,7 @@ const DEFAULT_STEP_EXPRESSION =
 
 function buildOperationDocument(options?: DocumentBuildOptions): BlueNode {
   const {
+    actorPolicyYaml,
     operationChannel,
     requestTypeYaml = 'type: Integer',
     handlerEventYaml,
@@ -64,6 +66,9 @@ function buildOperationDocument(options?: DocumentBuildOptions): BlueNode {
   const handlerEventSection = handlerEventYaml
     ? `    event:\n${indentBlock(handlerEventYaml.trim(), 6)}\n`
     : '';
+  const actorPolicySection = actorPolicyYaml
+    ? `  actorPolicy:\n${indentBlock(actorPolicyYaml.trim(), 4)}\n`
+    : '';
 
   const resolvedChangesetYaml =
     changesetYaml?.trim() ??
@@ -77,7 +82,7 @@ contracts:
   ownerChannel:
     type: Conversation/Timeline Channel
     timelineId: ${TIMELINE_ID}
-  ${OPERATION_KEY}:
+${actorPolicySection}  ${OPERATION_KEY}:
     type: ${operationType}
 ${operationChannelLine}    request:
 ${indentBlock(requestTypeYaml.trim(), 6)}
@@ -96,15 +101,23 @@ ${indentBlock(resolvedChangesetYaml, 10)}
 function operationRequestEvent(options?: {
   request?: unknown;
   allowNewerVersion?: boolean;
+  actor?: unknown;
   documentBlueId?: string;
   operation?: string;
+  source?: unknown;
 }): BlueNode {
   const {
     request = 1,
     allowNewerVersion = true,
+    actor,
     documentBlueId,
     operation = OPERATION_KEY,
+    source,
   } = options ?? {};
+  const entry: Record<string, unknown> = {
+    type: 'Conversation/Timeline Entry',
+    timeline: { timelineId: TIMELINE_ID },
+  };
   const message: Record<string, unknown> = {
     type: 'Conversation/Operation Request',
     operation,
@@ -116,11 +129,14 @@ function operationRequestEvent(options?: {
   if (documentBlueId) {
     message.document = { blueId: documentBlueId };
   }
-  return blue.jsonValueToNode({
-    type: 'Conversation/Timeline Entry',
-    timeline: { timelineId: TIMELINE_ID },
-    message,
-  });
+  if (actor !== undefined) {
+    entry.actor = actor;
+  }
+  if (source !== undefined) {
+    entry.source = source;
+  }
+  entry.message = message;
+  return blue.jsonValueToNode(entry);
 }
 
 function storedDocumentBlueId(document: BlueNode): string {
@@ -154,6 +170,181 @@ describe('SequentialWorkflowOperationProcessor', () => {
     const counterNode = property(result.document, 'counter');
     expect(numericValue(counterNode)).toBe(5);
     expect(result.triggeredEvents.length).toBe(0);
+  });
+
+  it('applies Actor Policy rules for principal actors in browser sessions', async () => {
+    const processor = buildProcessor(blue);
+    const init = await expectOk(
+      processor.initializeDocument(
+        buildOperationDocument({
+          actorPolicyYaml: `type: Conversation/Actor Policy
+operations:
+  ${OPERATION_KEY}:
+    requiresActor: principal
+    requiresSource: browserSession`,
+        }),
+      ),
+    );
+    const storedBlueId = storedDocumentBlueId(init.document);
+    const event = operationRequestEvent({
+      request: 2,
+      allowNewerVersion: false,
+      documentBlueId: storedBlueId,
+      actor: {
+        type: 'MyOS/MyOS Principal Actor',
+        accountId: 'alice-id',
+      },
+      source: {
+        type: 'Conversation/Browser Session',
+        uiSessionNonce: 'sess-1',
+      },
+    });
+
+    const result = await expectOk(
+      processor.processDocument(init.document.clone(), event),
+    );
+
+    expect(numericValue(property(result.document, 'counter'))).toBe(2);
+  });
+
+  it('skips workflow when Actor Policy rejects the actor category', async () => {
+    const processor = buildProcessor(blue);
+    const init = await expectOk(
+      processor.initializeDocument(
+        buildOperationDocument({
+          actorPolicyYaml: `type: Conversation/Actor Policy
+operations:
+  ${OPERATION_KEY}:
+    requiresActor: principal`,
+        }),
+      ),
+    );
+    const storedBlueId = storedDocumentBlueId(init.document);
+    const event = operationRequestEvent({
+      request: 3,
+      allowNewerVersion: false,
+      documentBlueId: storedBlueId,
+      actor: {
+        type: 'MyOS/MyOS Agent Actor',
+        accountId: 'openclaw-id',
+        onBehalfOf: {
+          type: 'MyOS/MyOS Principal Actor',
+          accountId: 'alice-id',
+        },
+      },
+      source: {
+        type: 'Conversation/API Call',
+        apiKeyId: 'key-123',
+      },
+    });
+
+    const result = await expectOk(
+      processor.processDocument(init.document.clone(), event),
+    );
+
+    expect(numericValue(property(result.document, 'counter'))).toBe(0);
+  });
+
+  it('accepts Actor Policy matches for agent actors and API sources', async () => {
+    const processor = buildProcessor(blue);
+    const init = await expectOk(
+      processor.initializeDocument(
+        buildOperationDocument({
+          actorPolicyYaml: `type: Conversation/Actor Policy
+operations:
+  ${OPERATION_KEY}:
+    requiresActor: agent
+    requiresSource: apiCall`,
+        }),
+      ),
+    );
+    const storedBlueId = storedDocumentBlueId(init.document);
+    const event = operationRequestEvent({
+      request: 4,
+      allowNewerVersion: false,
+      documentBlueId: storedBlueId,
+      actor: {
+        type: 'MyOS/MyOS Agent Actor',
+        accountId: 'openclaw-id',
+        onBehalfOf: {
+          type: 'MyOS/MyOS Principal Actor',
+          accountId: 'alice-id',
+        },
+      },
+      source: {
+        type: 'Conversation/API Call',
+        apiKeyId: 'key-123',
+      },
+    });
+
+    const result = await expectOk(
+      processor.processDocument(init.document.clone(), event),
+    );
+
+    expect(numericValue(property(result.document, 'counter'))).toBe(4);
+  });
+
+  // CHECK IT
+  it('treats requiresActor:any as requiring a recognized actor category', async () => {
+    const processor = buildProcessor(blue);
+    const init = await expectOk(
+      processor.initializeDocument(
+        buildOperationDocument({
+          actorPolicyYaml: `type: Conversation/Actor Policy
+operations:
+  ${OPERATION_KEY}:
+    requiresActor: any`,
+        }),
+      ),
+    );
+    const storedBlueId = storedDocumentBlueId(init.document);
+    const event = operationRequestEvent({
+      request: 5,
+      allowNewerVersion: false,
+      documentBlueId: storedBlueId,
+    });
+
+    const result = await expectOk(
+      processor.processDocument(init.document.clone(), event),
+    );
+
+    expect(numericValue(property(result.document, 'counter'))).toBe(0);
+  });
+
+  it('skips workflow when Actor Policy excludes the current source', async () => {
+    const processor = buildProcessor(blue);
+    const init = await expectOk(
+      processor.initializeDocument(
+        buildOperationDocument({
+          actorPolicyYaml: `type: Conversation/Actor Policy
+operations:
+  ${OPERATION_KEY}:
+    requiresActor: any
+    excludeSource: documentRequest`,
+        }),
+      ),
+    );
+    const storedBlueId = storedDocumentBlueId(init.document);
+    const event = operationRequestEvent({
+      request: 6,
+      allowNewerVersion: false,
+      documentBlueId: storedBlueId,
+      actor: {
+        type: 'MyOS/MyOS Principal Actor',
+        accountId: 'alice-id',
+      },
+      source: {
+        type: 'Conversation/Document Request',
+        documentId: 'doc-1',
+        epoch: 14,
+      },
+    });
+
+    const result = await expectOk(
+      processor.processDocument(init.document.clone(), event),
+    );
+
+    expect(numericValue(property(result.document, 'counter'))).toBe(0);
   });
 
   it('exposes derived channel in currentContract bindings', async () => {

--- a/libs/document-processor/src/registry/contract-processor-registry-builder.ts
+++ b/libs/document-processor/src/registry/contract-processor-registry-builder.ts
@@ -1,4 +1,5 @@
 import { ContractProcessorRegistry } from './contract-processor-registry.js';
+import { ActorPolicyMarkerProcessor } from './processors/actor-policy-marker-processor.js';
 import { CompositeTimelineChannelProcessor } from './processors/composite-timeline-channel-processor.js';
 import { MyOSTimelineChannelProcessor } from './processors/myos-timeline-channel-processor.js';
 import { TimelineChannelProcessor } from './processors/timeline-channel-processor.js';
@@ -22,6 +23,7 @@ export class ContractProcessorRegistryBuilder {
     this.registry.register(new MyOSTimelineChannelProcessor());
     this.registry.register(new TimelineChannelProcessor());
     this.registry.register(new SequentialWorkflowHandlerProcessor());
+    this.registry.register(new ActorPolicyMarkerProcessor());
     this.registry.register(new OperationMarkerProcessor());
     this.registry.register(new GenericMarkerProcessor());
     this.registry.register(new SequentialWorkflowOperationProcessor());

--- a/libs/document-processor/src/registry/processors/actor-policy-marker-processor.ts
+++ b/libs/document-processor/src/registry/processors/actor-policy-marker-processor.ts
@@ -1,0 +1,15 @@
+import { blueIds as conversationBlueIds } from '@blue-repository/types/packages/conversation/blue-ids';
+
+import {
+  actorPolicyMarkerSchema,
+  type ActorPolicyMarker,
+} from '../../model/index.js';
+import type { MarkerProcessor } from '../types.js';
+
+export class ActorPolicyMarkerProcessor implements MarkerProcessor<ActorPolicyMarker> {
+  readonly kind = 'marker' as const;
+  readonly blueIds = [
+    conversationBlueIds['Conversation/Actor Policy'],
+  ] as const;
+  readonly schema = actorPolicyMarkerSchema;
+}

--- a/libs/document-processor/src/registry/processors/sequential-workflow-operation-processor.ts
+++ b/libs/document-processor/src/registry/processors/sequential-workflow-operation-processor.ts
@@ -28,6 +28,7 @@ import {
   isRequestTypeCompatible,
   loadOperation,
 } from './workflow/operation-matcher.js';
+import { matchesActorPolicyForOperation } from './workflow/actor-policy.js';
 export class SequentialWorkflowOperationProcessor implements HandlerProcessor<SequentialWorkflowOperation> {
   readonly kind = 'handler' as const;
   readonly blueIds = [
@@ -129,6 +130,15 @@ export class SequentialWorkflowOperationProcessor implements HandlerProcessor<Se
       request?.allowNewerVersion === false &&
       !isPinnedDocumentAllowed(request, operationRequestNode, context)
     ) {
+      return false;
+    }
+
+    const operationKey = contract.operation;
+    if (!operationKey) {
+      return false;
+    }
+
+    if (!matchesActorPolicyForOperation(operationKey, eventNode, context)) {
       return false;
     }
 

--- a/libs/document-processor/src/registry/processors/workflow/actor-policy.ts
+++ b/libs/document-processor/src/registry/processors/workflow/actor-policy.ts
@@ -1,0 +1,149 @@
+import { BlueNode } from '@blue-labs/language';
+import { blueIds as conversationBlueIds } from '@blue-repository/types/packages/conversation/blue-ids';
+import { TimelineEntrySchema } from '@blue-repository/types/packages/conversation/schemas/TimelineEntry';
+
+import {
+  actorPolicyMarkerSchema,
+  type ActorPolicyMarker,
+  type ActorPolicyRule,
+} from '../../../model/index.js';
+import type { ContractProcessorContext } from '../../types.js';
+
+type ActorCategory = 'principal' | 'agent';
+type SourceCategory = 'browserSession' | 'apiCall' | 'documentRequest';
+
+const ACTOR_POLICY_BLUE_ID = conversationBlueIds['Conversation/Actor Policy'];
+const PRINCIPAL_ACTOR_BLUE_ID =
+  conversationBlueIds['Conversation/Principal Actor'];
+const AGENT_ACTOR_BLUE_ID = conversationBlueIds['Conversation/Agent Actor'];
+const BROWSER_SESSION_BLUE_ID =
+  conversationBlueIds['Conversation/Browser Session'];
+const API_CALL_BLUE_ID = conversationBlueIds['Conversation/API Call'];
+const DOCUMENT_REQUEST_BLUE_ID =
+  conversationBlueIds['Conversation/Document Request'];
+
+export function matchesActorPolicyForOperation(
+  operationKey: string,
+  eventNode: BlueNode,
+  context: ContractProcessorContext,
+): boolean {
+  const actorPolicy = loadActorPolicy(context);
+  const rule = actorPolicy?.operations?.[operationKey];
+  if (!rule) {
+    return true;
+  }
+
+  const actorCategory = classifyActorCategory(eventNode, context);
+  const sourceCategory = classifySourceCategory(eventNode, context);
+
+  return actorPolicyRuleMatches(rule, actorCategory, sourceCategory);
+}
+
+function loadActorPolicy(
+  context: ContractProcessorContext,
+): ActorPolicyMarker | null {
+  const contractsPointer = context.resolvePointer('/contracts');
+  const contractsNode = context.documentAt(contractsPointer);
+  const contractEntries = contractsNode?.getProperties();
+  if (!contractEntries) {
+    return null;
+  }
+
+  for (const contractNode of Object.values(contractEntries)) {
+    if (!(contractNode instanceof BlueNode)) {
+      continue;
+    }
+    if (!context.blue.isTypeOfBlueId(contractNode, ACTOR_POLICY_BLUE_ID)) {
+      continue;
+    }
+    return context.blue.nodeToSchemaOutput(
+      contractNode,
+      actorPolicyMarkerSchema,
+    );
+  }
+
+  return null;
+}
+
+function classifyActorCategory(
+  eventNode: BlueNode,
+  context: ContractProcessorContext,
+): ActorCategory | null {
+  const actorNode = timelineEntryChildNode(eventNode, 'actor', context);
+  if (!actorNode) {
+    return null;
+  }
+  if (context.blue.isTypeOfBlueId(actorNode, AGENT_ACTOR_BLUE_ID)) {
+    return 'agent';
+  }
+  if (context.blue.isTypeOfBlueId(actorNode, PRINCIPAL_ACTOR_BLUE_ID)) {
+    return 'principal';
+  }
+  return null;
+}
+
+function classifySourceCategory(
+  eventNode: BlueNode,
+  context: ContractProcessorContext,
+): SourceCategory | null {
+  const sourceNode = timelineEntryChildNode(eventNode, 'source', context);
+  if (!sourceNode) {
+    return null;
+  }
+  if (context.blue.isTypeOfBlueId(sourceNode, BROWSER_SESSION_BLUE_ID)) {
+    return 'browserSession';
+  }
+  if (context.blue.isTypeOfBlueId(sourceNode, API_CALL_BLUE_ID)) {
+    return 'apiCall';
+  }
+  if (context.blue.isTypeOfBlueId(sourceNode, DOCUMENT_REQUEST_BLUE_ID)) {
+    return 'documentRequest';
+  }
+  return null;
+}
+
+function timelineEntryChildNode(
+  eventNode: BlueNode,
+  propertyKey: 'actor' | 'source',
+  context: ContractProcessorContext,
+): BlueNode | null {
+  if (
+    !context.blue.isTypeOf(eventNode, TimelineEntrySchema, {
+      checkSchemaExtensions: true,
+    })
+  ) {
+    return null;
+  }
+
+  const rawChild = eventNode.getProperties()?.[propertyKey];
+  return rawChild instanceof BlueNode ? rawChild : null;
+}
+
+function actorPolicyRuleMatches(
+  rule: ActorPolicyRule,
+  actorCategory: ActorCategory | null,
+  sourceCategory: SourceCategory | null,
+): boolean {
+  if (rule.requiresActor) {
+    if (!actorCategory) {
+      return false;
+    }
+    if (rule.requiresActor !== 'any' && rule.requiresActor !== actorCategory) {
+      return false;
+    }
+  }
+
+  if (rule.requiresSource) {
+    if (!sourceCategory || rule.requiresSource !== sourceCategory) {
+      return false;
+    }
+  }
+
+  if (rule.excludeSource) {
+    if (!sourceCategory || rule.excludeSource === sourceCategory) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/libs/document-processor/src/test-support/blue.ts
+++ b/libs/document-processor/src/test-support/blue.ts
@@ -1,4 +1,5 @@
-import { Blue, Properties } from '@blue-labs/language';
+import type { JsonValue } from '@blue-labs/shared-utils';
+import { Blue, BlueIdCalculator, Properties } from '@blue-labs/language';
 import type { BlueRepository } from '@blue-labs/language';
 import { repository as blueRepository } from '@blue-repository/types';
 import { blueIds as coreBlueIds } from '@blue-repository/types/packages/core/blue-ids';
@@ -74,4 +75,71 @@ export function createBlue(): Blue {
   });
 }
 
+export function createBlueWithDerivedTypes(
+  definitions: Array<{ name: string; yaml: string }>,
+): { blue: Blue; derivedBlueIds: Record<string, string> } {
+  const seedBlue = createBlue();
+  const types = definitions.map(({ name, yaml }) => {
+    const node = seedBlue.yamlToNode(yaml);
+    const blueId = BlueIdCalculator.calculateBlueIdSync(node);
+    return { name, blueId, json: seedBlue.nodeToJson(node) };
+  });
+
+  const derivedRepository = buildDerivedTestRepository(types);
+  const blue = new Blue({
+    repositories: [blueRepository, testFallbackRepository, derivedRepository],
+    mergingProcessor: createDefaultMergingProcessor(),
+  });
+
+  for (const { name, blueId } of types) {
+    blue.registerBlueIds({ [name]: blueId });
+  }
+
+  return {
+    blue,
+    derivedBlueIds: Object.fromEntries(
+      types.map(({ name, blueId }) => [name, blueId]),
+    ),
+  };
+}
+
 export const blueIds = coreBlueIds;
+
+function buildDerivedTestRepository(
+  types: Array<{ name: string; blueId: string; json: JsonValue }>,
+): BlueRepository {
+  const typesMeta = Object.fromEntries(
+    types.map(({ name, blueId }) => [
+      blueId,
+      {
+        status: 'stable' as const,
+        name,
+        versions: [
+          {
+            repositoryVersionIndex: 0,
+            typeBlueId: blueId,
+            attributesAdded: [],
+          },
+        ],
+      },
+    ]),
+  );
+
+  const contents = Object.fromEntries(
+    types.map(({ blueId, json }) => [blueId, json]),
+  );
+
+  return {
+    name: 'test.derived.repo',
+    repositoryVersions: ['R0'],
+    packages: {
+      derived: {
+        name: 'derived',
+        aliases: {},
+        typesMeta,
+        contents,
+        schemas: {},
+      },
+    },
+  };
+}


### PR DESCRIPTION
## What changed
- added dedicated `Conversation/Actor Policy` marker support in `document-processor`, including schema/model registration and default registry wiring
- preserved parsed `operations` data in marker loading instead of falling back to the generic marker shape
- enforced actor/source policy checks in `Conversation/Sequential Workflow Operation` matching using raw timeline entry actor/source nodes
- added validation and regression coverage for policy parsing, duplicate policy detection, invalid literals, and operation matching behavior

## Why it changed
`Conversation/Actor Policy` existed in repository types, but `document-processor` did not execute the contract semantics. The processor needed to understand the marker shape and apply policy constraints during operation workflow matching.

## Impact
Documents can now declare per-operation actor/source constraints with `Conversation/Actor Policy`, and unsupported operation invocations are skipped consistently during processing.

## Root cause
The processor previously treated this contract as an untyped/generic marker at best and had no operation-level enforcement logic for actor/source policy rules.

## Validation
- `npx tsc -p libs/document-processor/tsconfig.lib.json --noEmit`
- `npx eslint libs/document-processor --fix`
- `nx test document-processor --skip-nx-cache`
