### PR TITLE
fix(release): resolve preview prerelease versioning

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -28,7 +28,8 @@
   "release": {
     "version": {
       "preVersionCommand": "npx nx run-many -t build",
-      "conventionalCommits": true
+      "conventionalCommits": true,
+      "preserveMatchingDependencyRanges": false
     },
     "changelog": {
       "workspaceChangelog": {
@@ -39,7 +40,8 @@
       }
     },
     "releaseTag": {
-      "checkAllBranchesWhen": "main"
+      "checkAllBranchesWhen": "main",
+      "strictPreid": false
     }
   },
   "plugins": [


### PR DESCRIPTION
Updates Nx release config so preview releases from next resolve from the latest stable tag instead of the old 2.0.0-rc line, and allows internal workspace dependency ranges to be rewritten to the RC version during release.