### PR TITLE
fix(repository-generator): preserve expressions during semantic blue id calculation

### DIFF
--- a/libs/repository-generator/src/__tests__/generateRepository.test.ts
+++ b/libs/repository-generator/src/__tests__/generateRepository.test.ts
@@ -6,6 +6,8 @@ import { Blue, createNodeProvider } from '@blue-labs/language';
 import type { JsonValue } from '@blue-labs/shared-utils';
 import { generateRepository } from '../lib/generateRepository';
 import { lookupStorageContentByBlueId } from '../lib/core/blueIds';
+import { PRIMITIVE_BLUE_IDS } from '../lib/core/constants';
+import { createRepositoryGeneratorMergingProcessor } from '../lib/core/mergingProcessor';
 import type { BluePackage, BlueTypeMetadata } from '../lib/types';
 
 type JsonMap = Record<string, JsonValue>;
@@ -40,7 +42,10 @@ const createSemanticExpectedCalculator = () => {
       parserBlue.jsonValueToNode(content),
     ),
   );
-  const blue = new Blue({ nodeProvider: provider });
+  const blue = new Blue({
+    nodeProvider: provider,
+    mergingProcessor: createRepositoryGeneratorMergingProcessor(),
+  });
 
   return {
     calculate(content: JsonMap): string {
@@ -1537,5 +1542,63 @@ score: 1.5
 
     expect(meta?.versions.at(-1)?.typeBlueId).toEqual(expectedBlueId);
     expect(meta?.content).toEqual(expectedContent);
+  });
+
+  it('preserves expression values without conflicting with inherited list fields', () => {
+    const expression = '${steps.Prepare.changeset}';
+    const repoRoot = createRepo();
+    writeType(
+      repoRoot,
+      'Core',
+      'JsonPatchEntry.blue',
+      `
+name: Json Patch Entry
+op:
+  type: Text
+path:
+  type: Text
+`,
+    );
+    writeType(
+      repoRoot,
+      'Conversation',
+      'UpdateDocument.blue',
+      `
+name: Update Document
+changeset:
+  type: List
+  itemType: Core/Json Patch Entry
+`,
+    );
+    writeType(
+      repoRoot,
+      'Conversation',
+      'ApplyStep.blue',
+      `
+name: Apply Step
+type: Conversation/Update Document
+changeset: '\${steps.Prepare.changeset}'
+`,
+    );
+
+    const result = generateRepository({
+      repoRoot,
+      blueRepositoryPath: path.join(repoRoot, BLUE_REPOSITORY),
+    });
+
+    const conversationPkg = result.document.packages.find(
+      (p: BluePackage) => p.name === 'Conversation',
+    );
+    const applyStep = conversationPkg?.types.find(
+      (t: BlueTypeMetadata) =>
+        (t.content as { name?: string }).name === 'Apply Step',
+    );
+    const applyStepContent = applyStep?.content as JsonMap | undefined;
+
+    expect(applyStep?.versions.at(-1)?.typeBlueId).toBeDefined();
+    expect(applyStepContent?.changeset).toEqual({
+      value: expression,
+      type: { blueId: PRIMITIVE_BLUE_IDS.Text },
+    });
   });
 });

--- a/libs/repository-generator/src/lib/core/ExpressionPreserver.ts
+++ b/libs/repository-generator/src/lib/core/ExpressionPreserver.ts
@@ -1,0 +1,42 @@
+import { BlueNode, type MergingProcessor } from '@blue-labs/language';
+
+const EXPRESSION_PATTERN = /^\$\{([\s\S]*)\}$/;
+
+export class ExpressionPreserver implements MergingProcessor {
+  process(target: BlueNode, source: BlueNode): BlueNode {
+    const sourceValue = source.getValue();
+
+    if (isExpression(sourceValue)) {
+      const expressionNode = source.clone();
+      expressionNode.setValue(sourceValue);
+      expressionNode.setProperties(undefined);
+      expressionNode.setItems(undefined);
+      expressionNode.setType(undefined);
+      return expressionNode;
+    }
+
+    return target;
+  }
+
+  postProcess(target: BlueNode, source: BlueNode): BlueNode {
+    const sourceValue = source.getValue();
+
+    if (isExpression(sourceValue) && target.getValue() !== sourceValue) {
+      const fixed = target.clone();
+      fixed.setValue(sourceValue);
+      return fixed;
+    }
+
+    return target;
+  }
+}
+
+function isExpression(value: unknown): value is string {
+  if (typeof value !== 'string') {
+    return false;
+  }
+  if (!EXPRESSION_PATTERN.test(value)) {
+    return false;
+  }
+  return value.indexOf('${') === value.lastIndexOf('${');
+}

--- a/libs/repository-generator/src/lib/core/blueIds.ts
+++ b/libs/repository-generator/src/lib/core/blueIds.ts
@@ -4,6 +4,7 @@ import type { JsonValue } from '@blue-labs/shared-utils';
 import { Alias, DiscoveredType, JsonMap } from './internalTypes';
 import { PRIMITIVE_BLUE_IDS, PRIMITIVE_TYPES } from './constants';
 import { cloneJson, isRecord } from './utils';
+import { createRepositoryGeneratorMergingProcessor } from './mergingProcessor';
 
 export function computeBlueIds(
   topoOrder: Alias[],
@@ -21,7 +22,10 @@ export function computeBlueIds(
       parserBlue.jsonValueToNode(content),
     ),
   );
-  const blue = new Blue({ nodeProvider: provider });
+  const blue = new Blue({
+    nodeProvider: provider,
+    mergingProcessor: createRepositoryGeneratorMergingProcessor(),
+  });
 
   for (const alias of topoOrder) {
     const type = discovered.get(alias);

--- a/libs/repository-generator/src/lib/core/mergingProcessor.ts
+++ b/libs/repository-generator/src/lib/core/mergingProcessor.ts
@@ -1,0 +1,14 @@
+import { type MergingProcessor, MergingProcessors } from '@blue-labs/language';
+import { ExpressionPreserver } from './ExpressionPreserver';
+
+export function createRepositoryGeneratorMergingProcessor(): MergingProcessor {
+  return new MergingProcessors.SequentialMergingProcessor([
+    new MergingProcessors.ValuePropagator(),
+    new ExpressionPreserver(),
+    new MergingProcessors.TypeAssigner(),
+    new MergingProcessors.ListProcessor(),
+    new MergingProcessors.DictionaryProcessor(),
+    new MergingProcessors.MetadataPropagator(),
+    new MergingProcessors.BasicTypesVerifier(),
+  ]);
+}


### PR DESCRIPTION
## Summary
- add repository-generator-local ExpressionPreserver before TypeAssigner
- use the custom merging processor for semantic typeBlueId calculation
- cover expression-over-list inheritance with a regression test

## Verification
- npx nx test repository-generator --skip-nx-cache
- npx nx lint repository-generator --skip-nx-cache
- npx nx typecheck repository-generator --skip-nx-cache
- npx nx build repository-generator --skip-nx-cache

## Integration smoke
- local blue-repository generation now gets past Text vs List and stops at the expected breaking-change guard: Type Conversation/Response content is unchanged but BlueId differs from previous metadata.