### PR TITLE
fix(language): minimize own type overlays

### DIFF
--- a/libs/language/src/lib/utils/MergeReverser.ts
+++ b/libs/language/src/lib/utils/MergeReverser.ts
@@ -23,7 +23,7 @@ export class MergeReverser {
 
   public reverse<T extends BlueNode>(mergedNode: T): BlueNode {
     const minimalNode = new BlueNode();
-    this.reverseNode(minimalNode, mergedNode, mergedNode.getType(), true);
+    this.reverseNode(minimalNode, mergedNode, undefined, true);
     return minimalNode;
   }
 
@@ -44,17 +44,27 @@ export class MergeReverser {
   private reverseNode(
     minimal: BlueNode,
     merged: BlueNode,
-    fromType: BlueNode | undefined,
+    externalFromType: BlueNode | undefined,
     isRoot: boolean,
   ): void {
-    if (!isRoot && this.isIdenticalToType(merged, fromType)) {
+    const effectiveFromType = this.getEffectiveFromType(
+      externalFromType,
+      merged,
+    );
+
+    if (!isRoot && this.isIdenticalToType(merged, effectiveFromType)) {
       return;
     }
 
-    this.reverseBasicProperties(minimal, merged, fromType, isRoot);
-    this.reverseTypeReferences(minimal, merged, fromType);
-    this.reverseItems(minimal, merged, fromType);
-    this.reverseProperties(minimal, merged, fromType);
+    this.reverseBasicProperties(minimal, merged, effectiveFromType, isRoot);
+    this.reverseTypeReferences(
+      minimal,
+      merged,
+      externalFromType,
+      effectiveFromType,
+    );
+    this.reverseItems(minimal, merged, effectiveFromType);
+    this.reverseProperties(minimal, merged, effectiveFromType);
   }
 
   private isIdenticalToType(
@@ -111,41 +121,80 @@ export class MergeReverser {
   private reverseTypeReferences(
     minimal: BlueNode,
     merged: BlueNode,
-    fromType: BlueNode | undefined,
+    externalFromType: BlueNode | undefined,
+    effectiveFromType: BlueNode | undefined,
   ): void {
     const setIfDifferent = (
       getter: (node: BlueNode) => BlueNode | undefined,
       setter: (node: BlueNode, value: BlueNode) => void,
+      fromType: BlueNode | undefined,
     ) => {
       const mergedTypeRef = getter(merged);
       const fromTypeRef = fromType ? getter(fromType) : undefined;
-      const mergedBlueId = mergedTypeRef?.getBlueId();
 
       if (
-        isNonNullable(mergedBlueId) &&
-        (isNullable(fromTypeRef?.getBlueId()) ||
-          mergedBlueId !== fromTypeRef.getBlueId())
+        isNonNullable(mergedTypeRef) &&
+        !this.areTypeReferencesEquivalent(mergedTypeRef, fromTypeRef)
       ) {
-        setter(minimal, new BlueNode().setBlueId(mergedBlueId));
+        setter(minimal, this.toMinimalTypeReference(mergedTypeRef));
       }
     };
 
     setIfDifferent(
       (n) => n.getType(),
       (n, v) => n.setType(v),
+      externalFromType,
     );
     setIfDifferent(
       (n) => n.getItemType(),
       (n, v) => n.setItemType(v),
+      effectiveFromType,
     );
     setIfDifferent(
       (n) => n.getKeyType(),
       (n, v) => n.setKeyType(v),
+      effectiveFromType,
     );
     setIfDifferent(
       (n) => n.getValueType(),
       (n, v) => n.setValueType(v),
+      effectiveFromType,
     );
+  }
+
+  private areTypeReferencesEquivalent(
+    mergedTypeRef: BlueNode,
+    fromTypeRef: BlueNode | undefined,
+  ): boolean {
+    if (isNullable(fromTypeRef)) {
+      return false;
+    }
+
+    const mergedBlueId = mergedTypeRef.getBlueId();
+    const fromBlueId = fromTypeRef.getBlueId();
+    if (isNonNullable(mergedBlueId) || isNonNullable(fromBlueId)) {
+      return (
+        isNonNullable(mergedBlueId) &&
+        isNonNullable(fromBlueId) &&
+        mergedBlueId === fromBlueId
+      );
+    }
+
+    return (
+      MergeReverser.calculateHashMinimalBlueId(mergedTypeRef) ===
+      MergeReverser.calculateHashMinimalBlueId(fromTypeRef)
+    );
+  }
+
+  private toMinimalTypeReference(typeRef: BlueNode): BlueNode {
+    const blueId = typeRef.getBlueId();
+    if (isNonNullable(blueId)) {
+      return new BlueNode().setBlueId(blueId);
+    }
+
+    const minimalType = new BlueNode();
+    this.reverseNode(minimalType, typeRef, undefined, true);
+    return Nodes.isEmptyNode(minimalType) ? typeRef.clone() : minimalType;
   }
 
   private reverseItems(
@@ -269,11 +318,7 @@ export class MergeReverser {
     const minimalProperties: Record<string, BlueNode> = {};
 
     for (const [key, mergedProperty] of Object.entries(mergedProperties)) {
-      const inheritedProperty = this.getInheritedProperty(
-        key,
-        merged,
-        fromType,
-      );
+      const inheritedProperty = this.getInheritedProperty(key, fromType);
 
       const minimalProperty = new BlueNode();
       this.reverseNode(
@@ -294,30 +339,52 @@ export class MergeReverser {
   }
 
   /**
-   * Determines what a property inherits from by combining contributions
-   * from both the parent type and the node's own type.
+   * Determines what a property inherits from after parent and own type overlays
+   * have already been combined for the current node.
    */
   private getInheritedProperty(
     key: string,
-    merged: BlueNode,
     fromType: BlueNode | undefined,
   ): BlueNode | undefined {
-    const fromParentType = fromType?.getProperties()?.[key];
-    const fromOwnType = merged.getType()?.getProperties()?.[key];
+    return fromType?.getProperties()?.[key];
+  }
 
-    if (isNullable(fromParentType) && isNullable(fromOwnType)) {
+  private getEffectiveFromType(
+    externalFromType: BlueNode | undefined,
+    merged: BlueNode,
+  ): BlueNode | undefined {
+    const ownTypeOverlay = this.createOwnTypeOverlay(merged.getType());
+
+    if (isNullable(externalFromType)) {
+      return ownTypeOverlay;
+    }
+
+    if (isNullable(ownTypeOverlay)) {
+      return externalFromType;
+    }
+
+    return this.mergeNodes(externalFromType, ownTypeOverlay);
+  }
+
+  private createOwnTypeOverlay(
+    ownType: BlueNode | undefined,
+  ): BlueNode | undefined {
+    if (isNullable(ownType)) {
       return undefined;
     }
 
-    if (isNullable(fromParentType)) {
-      return fromOwnType;
-    }
-    if (isNullable(fromOwnType)) {
-      return fromParentType;
+    const overlay = ownType
+      .cloneShallow()
+      .setName(undefined)
+      .setDescription(undefined)
+      .setType(undefined)
+      .setBlueId(undefined);
+
+    if (Nodes.isEmptyNode(overlay)) {
+      return undefined;
     }
 
-    // Both contribute - merge them (own type wins in conflicts)
-    return this.mergeNodes(fromParentType, fromOwnType);
+    return overlay;
   }
 
   /**
@@ -357,7 +424,9 @@ export class MergeReverser {
     if (isNonNullable(overlayProps)) {
       const mergedProps = merged.getProperties() || {};
       for (const [k, v] of Object.entries(overlayProps)) {
-        mergedProps[k] = v.clone();
+        const existing = mergedProps[k];
+        mergedProps[k] =
+          existing === undefined ? v.clone() : this.mergeNodes(existing, v);
       }
       merged.setProperties(mergedProps);
     }

--- a/libs/language/src/lib/utils/__tests__/MergeReverser.test.ts
+++ b/libs/language/src/lib/utils/__tests__/MergeReverser.test.ts
@@ -107,6 +107,276 @@ describe('MergeReverser', () => {
     expect(reversed.get('/z/itemType/blueId')).toEqual(TEXT_TYPE_BLUE_ID);
   });
 
+  it('removes collection type details re-derivable from a property own type', () => {
+    const nodeProvider = new BasicNodeProvider();
+    const blue = new Blue({ nodeProvider });
+
+    nodeProvider.addSingleDocs(`
+name: Anchor
+template:
+  description: Optional document-shaped template.
+`);
+
+    nodeProvider.addSingleDocs(`
+name: Anchors
+type: Dictionary
+keyType: Text
+valueType:
+  blueId: ${nodeProvider.getBlueIdByName('Anchor')}
+`);
+
+    const anchorsTypeId = nodeProvider.getBlueIdByName('Anchors');
+
+    const source = blue.yamlToNode(`
+name: Space Like
+anchors:
+  description: Optional named connection points.
+  type:
+    blueId: ${anchorsTypeId}
+`);
+
+    const resolved = blue.resolve(source);
+    const minimal = blue.minimize(resolved);
+    const minimalAnchors = minimal.getAsNode('/anchors');
+
+    expect(minimalAnchors?.getType()?.getBlueId()).toBe(anchorsTypeId);
+    expect(minimalAnchors?.getKeyType()).toBeUndefined();
+    expect(minimalAnchors?.getValueType()).toBeUndefined();
+    expect(blue.calculateBlueIdSync(minimal)).toBe(
+      blue.calculateBlueIdSync(resolved),
+    );
+  });
+
+  it('removes list itemType re-derivable from a property own type', () => {
+    const nodeProvider = new BasicNodeProvider();
+    const blue = new Blue({ nodeProvider });
+
+    nodeProvider.addSingleDocs(`
+name: Entry
+label:
+  type: Text
+`);
+
+    nodeProvider.addSingleDocs(`
+name: Entry List
+type: List
+itemType:
+  blueId: ${nodeProvider.getBlueIdByName('Entry')}
+`);
+
+    const entryListTypeId = nodeProvider.getBlueIdByName('Entry List');
+    const source = blue.yamlToNode(`
+name: Catalog
+entries:
+  type:
+    blueId: ${entryListTypeId}
+`);
+
+    const resolved = blue.resolve(source);
+    const minimal = blue.minimize(resolved);
+    const minimalEntries = minimal.getAsNode('/entries');
+
+    expect(minimalEntries?.getType()?.getBlueId()).toBe(entryListTypeId);
+    expect(minimalEntries?.getItemType()).toBeUndefined();
+    expect(blue.calculateBlueIdSync(minimal)).toBe(
+      blue.calculateBlueIdSync(resolved),
+    );
+  });
+
+  it('removes fixed scalar values re-derivable from a property own type', () => {
+    const nodeProvider = new BasicNodeProvider();
+    const blue = new Blue({ nodeProvider });
+
+    nodeProvider.addSingleDocs(`
+name: Fixed Text
+type: Text
+value: locked
+`);
+
+    const fixedTextTypeId = nodeProvider.getBlueIdByName('Fixed Text');
+    const source = blue.yamlToNode(`
+name: Fixed Text Holder
+field:
+  type:
+    blueId: ${fixedTextTypeId}
+`);
+
+    const resolved = blue.resolve(source);
+    const minimal = blue.minimize(resolved);
+    const minimalField = minimal.getAsNode('/field');
+
+    expect(minimalField?.getType()?.getBlueId()).toBe(fixedTextTypeId);
+    expect(minimalField?.getValue()).toBeUndefined();
+    expect(blue.calculateBlueIdSync(minimal)).toBe(
+      blue.calculateBlueIdSync(resolved),
+    );
+  });
+
+  it('emits append overlay for fixed items from a property own type', () => {
+    const nodeProvider = new BasicNodeProvider();
+    const blue = new Blue({ nodeProvider });
+
+    nodeProvider.addSingleDocs(`
+name: Fixed Options
+type: List
+items:
+  - A
+  - B
+`);
+
+    const fixedOptionsTypeId = nodeProvider.getBlueIdByName('Fixed Options');
+    const source = blue.yamlToNode(`
+name: Option Holder
+options:
+  type:
+    blueId: ${fixedOptionsTypeId}
+  items:
+    - A
+    - B
+    - C
+`);
+
+    const resolved = blue.resolve(source);
+    const minimal = blue.minimize(resolved);
+    const minimalOptions = minimal.getAsNode('/options');
+    const minimalItems = minimalOptions?.getItems();
+
+    expect(minimalOptions?.getType()?.getBlueId()).toBe(fixedOptionsTypeId);
+    expectPreviousAnchorWithStringDeltas(minimalItems, ['C']);
+    expect(blue.calculateBlueIdSync(minimal)).toBe(
+      blue.calculateBlueIdSync(resolved),
+    );
+  });
+
+  it('preserves refined collection constraints not re-derivable from a property own type', () => {
+    const nodeProvider = new BasicNodeProvider();
+    const blue = new Blue({ nodeProvider });
+
+    nodeProvider.addSingleDocs(`
+name: Base Entry
+base: true
+`);
+
+    nodeProvider.addSingleDocs(`
+name: Specialized Entry
+type:
+  blueId: ${nodeProvider.getBlueIdByName('Base Entry')}
+specialized: true
+`);
+
+    const baseEntryId = nodeProvider.getBlueIdByName('Base Entry');
+    const specializedEntryId =
+      nodeProvider.getBlueIdByName('Specialized Entry');
+
+    nodeProvider.addSingleDocs(`
+name: Base Entry List
+type: List
+itemType:
+  blueId: ${baseEntryId}
+`);
+
+    nodeProvider.addSingleDocs(`
+name: Base Entry Dictionary
+type: Dictionary
+keyType: Text
+valueType:
+  blueId: ${baseEntryId}
+`);
+
+    const listTypeId = nodeProvider.getBlueIdByName('Base Entry List');
+    const dictionaryTypeId = nodeProvider.getBlueIdByName(
+      'Base Entry Dictionary',
+    );
+    const source = blue.yamlToNode(`
+name: Refined Collections
+entries:
+  type:
+    blueId: ${listTypeId}
+  itemType:
+    blueId: ${specializedEntryId}
+entriesByName:
+  type:
+    blueId: ${dictionaryTypeId}
+  valueType:
+    blueId: ${specializedEntryId}
+`);
+
+    const resolved = blue.resolve(source);
+    const minimal = blue.minimize(resolved);
+    const minimalEntries = minimal.getAsNode('/entries');
+    const minimalEntriesByName = minimal.getAsNode('/entriesByName');
+
+    expect(minimalEntries?.getType()?.getBlueId()).toBe(listTypeId);
+    expect(minimalEntries?.getItemType()?.getBlueId()).toBe(specializedEntryId);
+    expect(minimalEntriesByName?.getType()?.getBlueId()).toBe(dictionaryTypeId);
+    expect(minimalEntriesByName?.getKeyType()).toBeUndefined();
+    expect(minimalEntriesByName?.getValueType()?.getBlueId()).toBe(
+      specializedEntryId,
+    );
+    expect(blue.calculateBlueIdSync(minimal)).toBe(
+      blue.calculateBlueIdSync(resolved),
+    );
+  });
+
+  it('preserves anonymous inline types while removing their re-derivable fields', () => {
+    const blue = new Blue();
+
+    const source = blue.yamlToNode(`
+name: Inline Type Holder
+field:
+  type:
+    fixed: value
+  fixed: value
+`);
+
+    const resolved = blue.resolve(source);
+    const minimal = blue.minimize(resolved);
+    const minimalField = minimal.getAsNode('/field');
+
+    expect(minimalField?.getType()).toBeDefined();
+    expect(minimalField?.getType()?.getProperties()?.fixed?.getValue()).toBe(
+      'value',
+    );
+    expect(minimalField?.getProperties()?.fixed).toBeUndefined();
+    expect(blue.calculateBlueIdSync(minimal)).toBe(
+      blue.calculateBlueIdSync(resolved),
+    );
+  });
+
+  it('does not inherit name or description from a property own type', () => {
+    const nodeProvider = new BasicNodeProvider();
+    const blue = new Blue({ nodeProvider });
+
+    nodeProvider.addSingleDocs(`
+name: Named Field Type
+description: Description from the type itself.
+fixed: value
+`);
+
+    const fieldTypeId = nodeProvider.getBlueIdByName('Named Field Type');
+    const source = blue.yamlToNode(`
+name: Own Type Metadata Holder
+field:
+  type:
+    blueId: ${fieldTypeId}
+`);
+
+    const resolved = blue.resolve(source);
+    const resolvedField = resolved.getAsNode('/field');
+    const minimal = blue.minimize(resolved);
+    const minimalField = minimal.getAsNode('/field');
+
+    expect(resolvedField?.getName()).toBeUndefined();
+    expect(resolvedField?.getDescription()).toBeUndefined();
+    expect(minimalField?.getType()?.getBlueId()).toBe(fieldTypeId);
+    expect(minimalField?.getName()).toBeUndefined();
+    expect(minimalField?.getDescription()).toBeUndefined();
+    expect(minimalField?.getProperties()?.fixed).toBeUndefined();
+    expect(blue.calculateBlueIdSync(minimal)).toBe(
+      blue.calculateBlueIdSync(resolved),
+    );
+  });
+
   it('testNestedTypes', () => {
     const nodeProvider = new BasicNodeProvider();
 

--- a/libs/repository-generator/src/__tests__/e2e-fixtures/base/BlueRepository.blue
+++ b/libs/repository-generator/src/__tests__/e2e-fixtures/base/BlueRepository.blue
@@ -24,7 +24,7 @@ packages:
             value: draft
         versions:
           - repositoryVersionIndex: 0
-            typeBlueId: 6rJ3veXS6KrmH1Uur8ktdDQn1Nsb4LH3VZmo23Aoy6nJ
+            typeBlueId: AXMDxCf9j8NzLe1CgiMCUevMNmbfjSKNHqECVk7TPkEM
             attributesAdded: []
       - status: dev
         content:
@@ -82,4 +82,4 @@ packages:
             typeBlueId: H8Gnf3e4d5kEtdpzFct7JgR71Um2DHe8NkNEv7ACU7rs
             attributesAdded: []
 repositoryVersions:
-  - 9eKjsgHqd9W93Cj7z194NKttJknz7KdCQCqwu3FnomS9
+  - 7k2vGWF3CxYX8dpgLiysvqy3MUf4u1Cif2kU7T2wvYJD

--- a/libs/repository-generator/src/__tests__/e2e-fixtures/dev-change/BlueRepository.blue
+++ b/libs/repository-generator/src/__tests__/e2e-fixtures/dev-change/BlueRepository.blue
@@ -24,7 +24,7 @@ packages:
             value: draft
         versions:
           - repositoryVersionIndex: 0
-            typeBlueId: 6rJ3veXS6KrmH1Uur8ktdDQn1Nsb4LH3VZmo23Aoy6nJ
+            typeBlueId: AXMDxCf9j8NzLe1CgiMCUevMNmbfjSKNHqECVk7TPkEM
             attributesAdded: []
       - status: dev
         content:
@@ -89,5 +89,5 @@ packages:
             typeBlueId: H8Gnf3e4d5kEtdpzFct7JgR71Um2DHe8NkNEv7ACU7rs
             attributesAdded: []
 repositoryVersions:
-  - 9eKjsgHqd9W93Cj7z194NKttJknz7KdCQCqwu3FnomS9
-  - GdEJVfdJqjGWWef5Sey1YDfaVwSSf49GGjyaNANBo5mV
+  - 7k2vGWF3CxYX8dpgLiysvqy3MUf4u1Cif2kU7T2wvYJD
+  - ExMJU1Vg9VQpe3iZjBZWxQeo3TsGwZcWu1S8Sxsi8RQh

--- a/libs/repository-generator/src/__tests__/e2e-fixtures/non-breaking/BlueRepository.blue
+++ b/libs/repository-generator/src/__tests__/e2e-fixtures/non-breaking/BlueRepository.blue
@@ -28,10 +28,10 @@ packages:
               blueId: DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K
         versions:
           - repositoryVersionIndex: 0
-            typeBlueId: 6rJ3veXS6KrmH1Uur8ktdDQn1Nsb4LH3VZmo23Aoy6nJ
+            typeBlueId: AXMDxCf9j8NzLe1CgiMCUevMNmbfjSKNHqECVk7TPkEM
             attributesAdded: []
           - repositoryVersionIndex: 1
-            typeBlueId: JBi2iQ6FvJ12XfnjHSFvZkYvJNxbp9ajnfR4xkQuFLq9
+            typeBlueId: HtJtgcffnRLxkty1pSaUkKo78eu8yoWzX5N9XVGCLsZk
             attributesAdded:
               - /note
       - status: dev
@@ -90,5 +90,5 @@ packages:
             typeBlueId: H8Gnf3e4d5kEtdpzFct7JgR71Um2DHe8NkNEv7ACU7rs
             attributesAdded: []
 repositoryVersions:
-  - 9eKjsgHqd9W93Cj7z194NKttJknz7KdCQCqwu3FnomS9
-  - HxAjQCL5czpYgSbBoBS5HbhdPRhJQPjzs3a8yrnMfWdD
+  - 7k2vGWF3CxYX8dpgLiysvqy3MUf4u1Cif2kU7T2wvYJD
+  - 8sTd8gEU2oj7c4A5zTUVukxhsbE6kAJxWMDcnwo3dWPP


### PR DESCRIPTION
## Summary
- account for a node's own resolved type overlay when minimizing resolved trees
- remove type-derived collection details, fixed values, and fixed list prefixes from minimal output
- preserve explicit refinements and anonymous inline types

## Tests
- npx vitest run --config libs/language/vite.config.ts libs/language/src/lib/utils/__tests__/MergeReverser.test.ts
- npx nx test language --skip-nx-cache
- npx tsc -p libs/language/tsconfig.lib.json --noEmit
- git diff --check

Note: full eslint over libs/language was attempted but hit Node heap/OOM, then the retry was stopped after hanging.