### PR TITLE
fix(language): trust semantic repository storage

### DIFF
--- a/libs/language/src/index.ts
+++ b/libs/language/src/index.ts
@@ -16,6 +16,7 @@ export {
   BasicNodeProvider,
   createNodeProvider,
   reindexRepositoryForSemanticStorage,
+  validateRepositorySemanticStorage,
   SemanticIdentityService,
 
   // merge

--- a/libs/language/src/lib/provider/RepositoryBasedNodeProvider.ts
+++ b/libs/language/src/lib/provider/RepositoryBasedNodeProvider.ts
@@ -3,15 +3,10 @@ import { NodeContentHandler } from './NodeContentHandler';
 import { BlueNode, NodeDeserializer } from '../model';
 import { JsonBlueValue } from '../../schema';
 import { BlueRepository } from '../types/BlueRepository';
-import { Preprocessor } from '../preprocess/Preprocessor';
-import { BlueIdsMappingGenerator } from '../preprocess/utils/BlueIdsMappingGenerator';
-import { SemanticStorageService } from '../identity/SemanticStorageService';
-import { NodeToMapListOrValue } from '../utils';
-import { BlueError, BlueErrorCode } from '../errors/BlueError';
 import type { MergingProcessor } from '../merge/MergingProcessor';
 
 /**
- * A NodeProvider that processes content from BlueRepository definitions.
+ * A NodeProvider that indexes content from trusted BlueRepository definitions.
  * Similar to Java's ClasspathBasedNodeProvider but for repository content.
  */
 export class RepositoryBasedNodeProvider extends PreloadedNodeProvider {
@@ -19,41 +14,16 @@ export class RepositoryBasedNodeProvider extends PreloadedNodeProvider {
   private blueIdToMultipleDocumentsMap: Map<string, boolean> = new Map();
   private aliasBlueIdMap: Map<string, string> = new Map();
 
-  // Repository contents can reference each other while the provider is still
-  // being built. These bootstrap maps are readable only during construction and
-  // are cleared once strict semantic storage keys have been verified.
-  private bootstrapBlueIdToContentMap: Map<string, JsonBlueValue> = new Map();
-  private bootstrapBlueIdToMultipleDocumentsMap: Map<string, boolean> =
-    new Map();
-  private readonly preprocessor: (node: BlueNode) => BlueNode;
-  private readonly storageService: SemanticStorageService;
-
   constructor(
     repositories: BlueRepository[],
-    options: { mergingProcessor?: MergingProcessor } = {},
+    _options: { mergingProcessor?: MergingProcessor } = {},
   ) {
     super();
 
-    const blueIdsMappingGenerator = new BlueIdsMappingGenerator();
     const aliasMappings =
       RepositoryBasedNodeProvider.collectAliasMappings(repositories);
     this.aliasBlueIdMap = new Map(Object.entries(aliasMappings));
-    if (Object.keys(aliasMappings).length > 0) {
-      blueIdsMappingGenerator.registerBlueIds(aliasMappings);
-    }
 
-    const defaultPreprocessor = new Preprocessor({
-      nodeProvider: this,
-      blueIdsMappingGenerator,
-    });
-    this.preprocessor = (node: BlueNode) =>
-      defaultPreprocessor.preprocessWithDefaultBlue(node);
-    this.storageService = new SemanticStorageService({
-      nodeProvider: this,
-      mergingProcessor: options.mergingProcessor,
-    });
-
-    // Process all repository contents
     this.loadRepositories(repositories);
   }
 
@@ -76,131 +46,27 @@ export class RepositoryBasedNodeProvider extends PreloadedNodeProvider {
   }
 
   private loadRepositories(repositories: BlueRepository[]): void {
-    // First pass makes package-provided keys available so semantic resolve can
-    // follow intra-repository references while each content item is processed.
     for (const repository of repositories) {
       Object.values(repository.packages).forEach((pkg) => {
         for (const [providedBlueId, content] of Object.entries(pkg.contents)) {
-          this.seedPreprocessedContent(providedBlueId, content);
+          this.storeContent(providedBlueId, content, Array.isArray(content));
+          this.addContentNames(providedBlueId, content);
         }
       });
     }
-
-    for (const repository of repositories) {
-      Object.values(repository.packages).forEach((pkg) => {
-        for (const [providedBlueId, content] of Object.entries(pkg.contents)) {
-          this.processContent(content, providedBlueId);
-        }
-      });
-    }
-
-    // After this point only semantic storage IDs remain externally fetchable.
-    this.bootstrapBlueIdToContentMap.clear();
-    this.bootstrapBlueIdToMultipleDocumentsMap.clear();
   }
 
-  private seedPreprocessedContent(
-    providedBlueId: string,
-    content: JsonBlueValue,
-  ): void {
+  private addContentNames(blueId: string, content: JsonBlueValue): void {
     if (Array.isArray(content)) {
-      const preprocessed = content.map((item) =>
-        NodeToMapListOrValue.get(
-          this.preprocessor(NodeDeserializer.deserialize(item)),
-        ),
-      );
-      this.bootstrapBlueIdToContentMap.set(providedBlueId, preprocessed);
-      this.bootstrapBlueIdToMultipleDocumentsMap.set(providedBlueId, true);
+      this.addListItemNames(blueId, content);
       return;
     }
 
-    const preprocessed = this.preprocessor(
-      NodeDeserializer.deserialize(content),
-    );
-    this.bootstrapBlueIdToContentMap.set(
-      providedBlueId,
-      NodeToMapListOrValue.get(preprocessed),
-    );
-    this.bootstrapBlueIdToMultipleDocumentsMap.set(providedBlueId, false);
-  }
-
-  private processContent(
-    content: JsonBlueValue,
-    providedBlueId?: string,
-  ): void {
-    if (Array.isArray(content)) {
-      this.processMultipleDocuments(content, providedBlueId);
-    } else {
-      this.processSingleDocument(content, providedBlueId);
-    }
-  }
-
-  private processSingleDocument(
-    content: JsonBlueValue,
-    providedBlueId?: string,
-  ): void {
     const node = NodeDeserializer.deserialize(content);
-    const parsedContent = NodeContentHandler.parseAndCalculateBlueIdForNode(
-      node,
-      this.preprocessor,
-      this.storageService,
-    );
-
-    this.assertProvidedBlueId(parsedContent.blueId, providedBlueId);
-    this.storeContent(parsedContent.blueId, parsedContent.content, false);
-
     const nodeName = node.getName();
     if (nodeName) {
-      this.addToNameMap(nodeName, parsedContent.blueId);
+      this.addToNameMap(nodeName, blueId);
     }
-  }
-
-  private processMultipleDocuments(
-    contents: JsonBlueValue[],
-    providedBlueId?: string,
-  ): void {
-    const nodes = contents.map((item) => {
-      const node = NodeDeserializer.deserialize(item);
-      return this.preprocessor(node);
-    });
-
-    const parsedContent = NodeContentHandler.parseAndCalculateBlueIdForNodeList(
-      nodes,
-      (node) => node,
-      this.storageService,
-    );
-
-    this.assertProvidedBlueId(parsedContent.blueId, providedBlueId);
-    this.storeContent(
-      parsedContent.blueId,
-      parsedContent.content,
-      parsedContent.isMultipleDocuments,
-    );
-
-    if (parsedContent.isCyclicSet) {
-      this.addListItemNames(parsedContent.blueId, parsedContent.content);
-      return;
-    }
-
-    nodes.forEach((node, index) => {
-      const itemBlueId = `${parsedContent.blueId}#${index}`;
-      const itemParsedContent =
-        NodeContentHandler.parseAndCalculateBlueIdForNode(
-          node,
-          (n) => n,
-          this.storageService,
-        );
-      this.blueIdToContentMap.set(
-        itemParsedContent.blueId,
-        itemParsedContent.content,
-      );
-      this.blueIdToMultipleDocumentsMap.set(itemParsedContent.blueId, false);
-
-      const nodeName = node.getName();
-      if (nodeName) {
-        this.addToNameMap(nodeName, itemBlueId);
-      }
-    });
   }
 
   private addListItemNames(blueId: string, content: JsonBlueValue): void {
@@ -220,24 +86,9 @@ export class RepositoryBasedNodeProvider extends PreloadedNodeProvider {
   protected override fetchContentByBlueId(
     baseBlueId: string,
   ): JsonBlueValue | null {
-    const finalContent = this.blueIdToContentMap.get(baseBlueId);
-    const finalIsMultipleDocuments =
-      this.blueIdToMultipleDocumentsMap.get(baseBlueId);
-
-    if (finalContent !== undefined && finalIsMultipleDocuments !== undefined) {
-      return NodeContentHandler.resolveThisReferences(
-        finalContent,
-        baseBlueId,
-        finalIsMultipleDocuments,
-      );
-    }
-
-    // Bootstrap lookup is only populated during constructor-time processing.
-    // It is not a historical-ID compatibility path after loadRepositories()
-    // clears the maps.
-    const content = this.bootstrapBlueIdToContentMap.get(baseBlueId);
+    const content = this.blueIdToContentMap.get(baseBlueId);
     const isMultipleDocuments =
-      this.bootstrapBlueIdToMultipleDocumentsMap.get(baseBlueId);
+      this.blueIdToMultipleDocumentsMap.get(baseBlueId);
 
     if (content !== undefined && isMultipleDocuments !== undefined) {
       return NodeContentHandler.resolveThisReferences(
@@ -325,29 +176,5 @@ export class RepositoryBasedNodeProvider extends PreloadedNodeProvider {
       baseBlueId: blueId.slice(0, separatorIndex),
       suffix: blueId.slice(separatorIndex),
     };
-  }
-
-  private assertProvidedBlueId(
-    computedBlueId: string,
-    providedBlueId?: string,
-  ): void {
-    if (providedBlueId === undefined) {
-      return;
-    }
-
-    if (providedBlueId !== computedBlueId) {
-      throw new BlueError(
-        BlueErrorCode.BLUE_ID_MISMATCH,
-        `Repository content key '${providedBlueId}' does not match semantic BlueId '${computedBlueId}'.`,
-        [
-          {
-            code: BlueErrorCode.BLUE_ID_MISMATCH,
-            message:
-              'Repository contents must be keyed by the semantic BlueId of their minimal storage form.',
-            context: { providedBlueId, computedBlueId },
-          },
-        ],
-      );
-    }
   }
 }

--- a/libs/language/src/lib/provider/__tests__/RepositoryBasedNodeProvider.test.ts
+++ b/libs/language/src/lib/provider/__tests__/RepositoryBasedNodeProvider.test.ts
@@ -3,7 +3,6 @@ import { RepositoryBasedNodeProvider } from '../RepositoryBasedNodeProvider';
 import { BasicNodeProvider } from '../BasicNodeProvider';
 import { BlueNode } from '../../model';
 import { BlueIdCalculator, NodeToMapListOrValue } from '../../utils';
-import { BlueErrorCode } from '../../errors/BlueError';
 import { Blue } from '../../Blue';
 
 describe('RepositoryBasedNodeProvider', () => {
@@ -93,7 +92,7 @@ describe('RepositoryBasedNodeProvider', () => {
     expect(provider.hasBlueId(currentId)).toBe(true);
   });
 
-  it('rejects repository content keys that do not match semantic BlueIds', () => {
+  it('loads repository content under provided keys without runtime BlueId validation', () => {
     const typeNode = new BlueNode('StrictType');
     const semanticId = BlueIdCalculator.calculateBlueIdSync(typeNode);
     const wrongId = 'wrong-repository-content-id';
@@ -125,9 +124,11 @@ describe('RepositoryBasedNodeProvider', () => {
       },
     };
 
-    expect(() => new RepositoryBasedNodeProvider([repository])).toThrow(
-      expect.objectContaining({ code: BlueErrorCode.BLUE_ID_MISMATCH }),
-    );
+    const provider = new RepositoryBasedNodeProvider([repository]);
+
+    expect(provider.hasBlueId(wrongId)).toBe(true);
+    expect(provider.fetchByBlueId(wrongId)?.[0]?.getName()).toBe('StrictType');
+    expect(provider.hasBlueId(semanticId)).toBe(false);
   });
 
   it('indexes names for new-style repositories', () => {
@@ -168,7 +169,7 @@ describe('RepositoryBasedNodeProvider', () => {
     expect(found?.getBlueId()).toBeUndefined();
   });
 
-  it('preprocesses repository content using alias mappings', () => {
+  it('does not preprocess repository content using alias mappings', () => {
     const childNode = new BlueNode('Child');
     const childId = BlueIdCalculator.calculateBlueIdSync(childNode);
     const parentNode = new BlueNode('Parent').setProperties({
@@ -229,7 +230,8 @@ describe('RepositoryBasedNodeProvider', () => {
       ? fetched[0]?.getProperties()?.child?.getType()
       : undefined;
 
-    expect(childType?.getBlueId()).toEqual(childId);
+    expect(childType?.getBlueId()).toBeUndefined();
+    expect(childType?.getValue()).toEqual('test/Child');
   });
 
   it('preserves # references for multi-document content', () => {
@@ -294,7 +296,8 @@ describe('RepositoryBasedNodeProvider', () => {
 
     const individualBlueId = BlueIdCalculator.calculateBlueIdSync(first);
     const byIndividual = provider.fetchByBlueId(individualBlueId);
-    expect(byIndividual?.[0]?.getBlueId()).toBeUndefined();
+    expect(byIndividual).toBeNull();
+    expect(provider.hasBlueId(individualBlueId)).toBe(false);
 
     const byName = provider.findNodeByName('First');
     expect(byName?.getBlueId()).toBeUndefined();

--- a/libs/language/src/lib/repository/SemanticRepositoryReindexer.ts
+++ b/libs/language/src/lib/repository/SemanticRepositoryReindexer.ts
@@ -5,6 +5,9 @@ import type { MergingProcessor } from '../merge/MergingProcessor';
 import { createDefaultMergingProcessor } from '../merge';
 import type { BlueRepository } from '../types/BlueRepository';
 import { withTypeBlueId } from '../../schema/annotations';
+import type { JsonBlueValue } from '../../schema';
+import { NodeContentHandler } from '../provider/NodeContentHandler';
+import { BlueError, BlueErrorCode } from '../errors/BlueError';
 
 interface RepositoryEntry {
   packageName: string;
@@ -13,6 +16,10 @@ interface RepositoryEntry {
 }
 
 export interface SemanticRepositoryReindexOptions {
+  mergingProcessor?: MergingProcessor;
+}
+
+export interface RepositorySemanticStorageValidationOptions {
   mergingProcessor?: MergingProcessor;
 }
 
@@ -73,6 +80,46 @@ export function reindexRepositoryForSemanticStorage(
   );
 }
 
+export function validateRepositorySemanticStorage(
+  repository: BlueRepository,
+  options: RepositorySemanticStorageValidationOptions = {},
+): void {
+  const entries = collectEntries(repository);
+  if (entries.length === 0) {
+    return;
+  }
+
+  const aliases = collectAliases(repository);
+  const mergingProcessor =
+    options.mergingProcessor ?? createDefaultMergingProcessor();
+  const validationBlue = new Blue({
+    nodeProvider: createRepositoryValidationProvider(entries, aliases),
+    mergingProcessor,
+  });
+  validationBlue.registerBlueIds(aliases);
+
+  for (const { packageName, oldBlueId, content } of entries) {
+    const prepared = Array.isArray(content)
+      ? content.map((item) => validationBlue.jsonValueToNode(item))
+      : validationBlue.jsonValueToNode(content);
+    const computedBlueId = validationBlue.calculateBlueIdSync(prepared);
+    if (computedBlueId !== oldBlueId) {
+      throw new BlueError(
+        BlueErrorCode.BLUE_ID_MISMATCH,
+        `Repository content key '${oldBlueId}' does not match semantic BlueId '${computedBlueId}'.`,
+        [
+          {
+            code: BlueErrorCode.BLUE_ID_MISMATCH,
+            message:
+              'Repository contents must be keyed by the semantic BlueId of their minimal storage form.',
+            context: { packageName, providedBlueId: oldBlueId, computedBlueId },
+          },
+        ],
+      );
+    }
+  }
+}
+
 function getMaxReindexPasses(entryCount: number): number {
   return Math.max(MIN_REINDEX_PASSES, entryCount + 1);
 }
@@ -95,6 +142,98 @@ function collectAliases(repository: BlueRepository): Record<string, string> {
     }
   }
   return aliases;
+}
+
+function createRepositoryValidationProvider(
+  entries: RepositoryEntry[],
+  aliases: Record<string, string>,
+) {
+  const contentByBlueId = new Map(
+    entries.map(({ oldBlueId, content }) => [oldBlueId, content]),
+  );
+  const aliasMap = new Map(Object.entries(aliases));
+  const parserBlue = new Blue();
+
+  return {
+    fetchByBlueId(blueId: string): BlueNode[] {
+      const resolvedBlueId = resolveAliasBlueId(blueId, aliasMap);
+      if (resolvedBlueId === undefined) {
+        return [];
+      }
+
+      const { baseBlueId, suffix } = getBaseBlueIdAndSuffix(resolvedBlueId);
+      const content = contentByBlueId.get(baseBlueId);
+      if (content === undefined) {
+        return [];
+      }
+
+      const isMultipleDocuments = Array.isArray(content);
+      const resolvedContent = NodeContentHandler.resolveThisReferences(
+        content as JsonBlueValue,
+        baseBlueId,
+        isMultipleDocuments,
+      );
+
+      if (suffix !== undefined) {
+        const index = Number(suffix.slice(1));
+        if (Array.isArray(resolvedContent)) {
+          const item = resolvedContent[index];
+          return item === undefined ? [] : [parserBlue.jsonValueToNode(item)];
+        }
+        return index === 0 ? [parserBlue.jsonValueToNode(resolvedContent)] : [];
+      }
+
+      if (Array.isArray(resolvedContent)) {
+        return resolvedContent.map((item) => parserBlue.jsonValueToNode(item));
+      }
+
+      return [parserBlue.jsonValueToNode(resolvedContent)];
+    },
+    fetchFirstByBlueId(blueId: string): BlueNode | null {
+      return this.fetchByBlueId(blueId)[0] ?? null;
+    },
+  };
+}
+
+function resolveAliasBlueId(
+  blueId: string,
+  aliasMap: Map<string, string>,
+): string | undefined {
+  const exactAlias = aliasMap.get(blueId);
+  if (exactAlias !== undefined) {
+    return exactAlias;
+  }
+
+  const { baseBlueId, suffix } = getBaseBlueIdAndSuffix(blueId);
+  if (suffix === undefined) {
+    return blueId;
+  }
+
+  const mappedBaseBlueId = aliasMap.get(baseBlueId);
+  if (mappedBaseBlueId === undefined) {
+    return blueId;
+  }
+
+  if (getBaseBlueIdAndSuffix(mappedBaseBlueId).suffix !== undefined) {
+    return undefined;
+  }
+
+  return `${mappedBaseBlueId}${suffix}`;
+}
+
+function getBaseBlueIdAndSuffix(blueId: string): {
+  baseBlueId: string;
+  suffix?: string;
+} {
+  const separatorIndex = blueId.indexOf('#');
+  if (separatorIndex === -1) {
+    return { baseBlueId: blueId };
+  }
+
+  return {
+    baseBlueId: blueId.slice(0, separatorIndex),
+    suffix: blueId.slice(separatorIndex),
+  };
 }
 
 function calculateSemanticIds(

--- a/libs/language/src/lib/repository/__tests__/SemanticRepositoryReindexer.test.ts
+++ b/libs/language/src/lib/repository/__tests__/SemanticRepositoryReindexer.test.ts
@@ -2,12 +2,14 @@ import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 import { Blue } from '../../Blue';
 import type { BlueRepository } from '../../types/BlueRepository';
+import { BlueErrorCode } from '../../errors/BlueError';
 import {
   getTypeBlueIdAnnotation,
   withTypeBlueId,
 } from '../../../schema/annotations';
 import {
   reindexRepositoryForSemanticStorage,
+  validateRepositorySemanticStorage,
   rewriteAliasMappings,
   rewriteBlueIds,
   rewriteBlueIdWithOptionalIndex,
@@ -52,7 +54,44 @@ describe('SemanticRepositoryReindexer', () => {
       ?.value?.[0];
     expect(parentTypeBlueId).toBe(parentId);
 
+    expect(() => validateRepositorySemanticStorage(reindexed)).not.toThrow();
     expect(() => new Blue({ repositories: [reindexed] })).not.toThrow();
+  });
+
+  it('validates repository content keys against semantic BlueIds', () => {
+    const content = { name: 'StrictType' };
+    const semanticId = new Blue().calculateBlueIdSync(content);
+    const repository: BlueRepository = {
+      name: 'strict.repository',
+      repositoryVersions: ['R0'],
+      packages: {
+        pkg: {
+          name: 'pkg',
+          aliases: { 'Pkg/StrictType': semanticId },
+          typesMeta: {
+            [semanticId]: {
+              status: 'stable',
+              name: 'StrictType',
+              versions: [
+                {
+                  repositoryVersionIndex: 0,
+                  typeBlueId: semanticId,
+                  attributesAdded: [],
+                },
+              ],
+            },
+          },
+          contents: {
+            'wrong-repository-content-id': content,
+          },
+          schemas: {},
+        },
+      },
+    };
+
+    expect(() => validateRepositorySemanticStorage(repository)).toThrow(
+      expect.objectContaining({ code: BlueErrorCode.BLUE_ID_MISMATCH }),
+    );
   });
 
   it('does not reuse the default cache for custom merging processors', () => {
@@ -152,7 +191,46 @@ describe('SemanticRepositoryReindexer', () => {
     expect(listId).toBeDefined();
     expect(pkg.aliases['Pkg/Second']).toBe(`${listId}#1`);
     expect(pkg.typesMeta[listId]?.versions[0]?.typeBlueId).toBe(`${listId}#1`);
+    expect(() => validateRepositorySemanticStorage(reindexed)).not.toThrow();
     expect(() => new Blue({ repositories: [reindexed] })).not.toThrow();
+  });
+
+  it('validates direct cyclic repository document sets', () => {
+    const contents = [
+      {
+        name: 'RepoA',
+        peer: {
+          blueId: 'this#1',
+        },
+      },
+      {
+        name: 'RepoB',
+        peer: {
+          blueId: 'this#0',
+        },
+      },
+    ];
+    const masterBlueId = new Blue().calculateBlueIdSync(contents);
+    const repository: BlueRepository = {
+      name: 'cyclic.repository',
+      repositoryVersions: ['R0'],
+      packages: {
+        pkg: {
+          name: 'pkg',
+          aliases: {
+            'Pkg/RepoA': `${masterBlueId}#0`,
+            'Pkg/RepoB': `${masterBlueId}#1`,
+          },
+          typesMeta: {},
+          contents: {
+            [masterBlueId]: contents,
+          },
+          schemas: {},
+        },
+      },
+    };
+
+    expect(() => validateRepositorySemanticStorage(repository)).not.toThrow();
   });
 
   it('reindexes dependency chains deeper than the previous fixed pass cap', () => {


### PR DESCRIPTION
## Summary
- make RepositoryBasedNodeProvider trust BlueRepository contents as semantic storage artifacts
- move expensive BlueId consistency checking to validateRepositorySemanticStorage()
- update provider and semantic repository reindexer regression tests

## Verification
- npx vitest run --config libs/language/vite.config.ts libs/language/src/lib/provider/__tests__/RepositoryBasedNodeProvider.test.ts libs/language/src/lib/repository/__tests__/SemanticRepositoryReindexer.test.ts
- npx nx test language --skip-nx-cache
- npx nx test document-processor --skip-nx-cache
- npx nx test dsl-sdk --skip-nx-cache
- npx nx test repository-generator --skip-nx-cache
- npx tsc -p libs/language/tsconfig.lib.json --noEmit
- git diff --check

Note: ESLint was skipped because the local linter currently hangs/OOMs.