### PR TITLE
fix(language): canonicalize cyclic repository indexes

### DIFF
--- a/libs/language/src/lib/provider/RepositoryBasedNodeProvider.ts
+++ b/libs/language/src/lib/provider/RepositoryBasedNodeProvider.ts
@@ -4,6 +4,7 @@ import { BlueNode, NodeDeserializer } from '../model';
 import { JsonBlueValue } from '../../schema';
 import { BlueRepository } from '../types/BlueRepository';
 import type { MergingProcessor } from '../merge/MergingProcessor';
+import { canonicalizeRepositoryContent } from '../repository/RepositoryContentCanonicalizer';
 
 /**
  * A NodeProvider that indexes content from trusted BlueRepository definitions.
@@ -49,8 +50,13 @@ export class RepositoryBasedNodeProvider extends PreloadedNodeProvider {
     for (const repository of repositories) {
       Object.values(repository.packages).forEach((pkg) => {
         for (const [providedBlueId, content] of Object.entries(pkg.contents)) {
-          this.storeContent(providedBlueId, content, Array.isArray(content));
-          this.addContentNames(providedBlueId, content);
+          const canonicalContent = canonicalizeRepositoryContent(content);
+          this.storeContent(
+            providedBlueId,
+            canonicalContent,
+            Array.isArray(canonicalContent),
+          );
+          this.addContentNames(providedBlueId, canonicalContent);
         }
       });
     }

--- a/libs/language/src/lib/provider/__tests__/RepositoryBasedNodeProvider.test.ts
+++ b/libs/language/src/lib/provider/__tests__/RepositoryBasedNodeProvider.test.ts
@@ -303,6 +303,56 @@ describe('RepositoryBasedNodeProvider', () => {
     expect(byName?.getBlueId()).toBeUndefined();
   });
 
+  it('canonicalizes direct cyclic document sets before indexing # references', () => {
+    const blue = new Blue();
+    const contents = [
+      {
+        name: 'A',
+        peer: {
+          blueId: 'this#1',
+        },
+      },
+      {
+        name: 'B',
+        peer: {
+          blueId: 'this#0',
+        },
+      },
+    ];
+    const masterBlueId = blue.calculateBlueIdSync(contents);
+    const repository = {
+      name: 'cyclic.repository',
+      repositoryVersions: ['R0'],
+      packages: {
+        pkg: {
+          name: 'pkg',
+          aliases: {
+            'Pkg/A': `${masterBlueId}#1`,
+            'Pkg/B': `${masterBlueId}#0`,
+          },
+          typesMeta: {},
+          contents: {
+            [masterBlueId]: contents,
+          },
+          schemas: {},
+        },
+      },
+    };
+
+    const provider = new RepositoryBasedNodeProvider([repository]);
+
+    expect(provider.fetchByBlueId(`${masterBlueId}#0`)?.[0]?.getName()).toBe(
+      'B',
+    );
+    expect(provider.fetchByBlueId(`${masterBlueId}#1`)?.[0]?.getName()).toBe(
+      'A',
+    );
+    expect(provider.fetchByBlueId('Pkg/A')?.[0]?.getName()).toBe('A');
+    expect(provider.fetchByBlueId('Pkg/B')?.[0]?.getName()).toBe('B');
+    expect(provider.findNodeByName('A')?.getName()).toBe('A');
+    expect(provider.findNodeByName('B')?.getName()).toBe('B');
+  });
+
   it('loads direct cyclic repository document sets under MASTER#i ids', () => {
     const first = new BlueNode('RepoA').addProperty(
       'peer',

--- a/libs/language/src/lib/repository/RepositoryContentCanonicalizer.ts
+++ b/libs/language/src/lib/repository/RepositoryContentCanonicalizer.ts
@@ -1,0 +1,31 @@
+import type { JsonBlueValue } from '../../schema';
+import { CyclicSetIdentityService } from '../identity/CyclicSetIdentityService';
+import { BlueNode, NodeDeserializer } from '../model';
+import { NodeToMapListOrValue } from '../utils';
+
+export function canonicalizeRepositoryContent(
+  content: JsonBlueValue,
+): JsonBlueValue {
+  if (!Array.isArray(content)) {
+    return content;
+  }
+
+  return canonicalizeRepositoryDocumentList(content);
+}
+
+export function canonicalizeRepositoryDocumentList(
+  content: JsonBlueValue[],
+): JsonBlueValue[] {
+  const nodes = content.map((item) => NodeDeserializer.deserialize(item));
+
+  if (!CyclicSetIdentityService.hasIndexedThisReference(nodes)) {
+    return content;
+  }
+
+  return canonicalizeRepositoryNodeList(nodes);
+}
+
+function canonicalizeRepositoryNodeList(nodes: BlueNode[]): JsonBlueValue[] {
+  const cyclicSet = new CyclicSetIdentityService().calculate(nodes);
+  return cyclicSet.nodes.map((node) => NodeToMapListOrValue.get(node));
+}


### PR DESCRIPTION
## Summary
- follow-up to #187 for the cyclic set indexing review comment
- canonicalize trusted repository arrays containing indexed this#k references before storing/indexing them
- add regression coverage for canonical master#index and alias lookups

## Verification
- npx vitest run --config libs/language/vite.config.ts libs/language/src/lib/provider/__tests__/RepositoryBasedNodeProvider.test.ts libs/language/src/lib/repository/__tests__/SemanticRepositoryReindexer.test.ts
- npx tsc -p libs/language/tsconfig.lib.json --noEmit
- git diff --check