### PR TITLE
fix(repository): use semantic repository artifact

### DIFF
--- a/libs/document-processor/package.json
+++ b/libs/document-processor/package.json
@@ -35,7 +35,7 @@
     "url": "git+https://github.com/bluecontract/blue-js.git"
   },
   "peerDependencies": {
-    "@blue-repository/types": ">=0.1.0 <1 || >=1.0.0-rc.0 <2",
+    "@blue-repository/types": ">=1.0.0-rc.0 <2",
     "zod": "^3.20.0"
   }
 }

--- a/libs/document-processor/package.json
+++ b/libs/document-processor/package.json
@@ -35,7 +35,7 @@
     "url": "git+https://github.com/bluecontract/blue-js.git"
   },
   "peerDependencies": {
-    "@blue-repository/types": ">=0.1.0 <1",
+    "@blue-repository/types": ">=0.1.0 <1 || >=1.0.0-rc.0 <2",
     "zod": "^3.20.0"
   }
 }

--- a/libs/document-processor/src/repository/semantic-repository.ts
+++ b/libs/document-processor/src/repository/semantic-repository.ts
@@ -1,19 +1,10 @@
-import { repository as rawBlueRepository } from '@blue-repository/types';
-import { blueIds as rawCoreBlueIds } from '@blue-repository/types/packages/core/blue-ids';
-import { blueIds as rawConversationBlueIds } from '@blue-repository/types/packages/conversation/blue-ids';
-import { blueIds as rawMyOsBlueIds } from '@blue-repository/types/packages/myos/blue-ids';
-import {
-  reindexRepositoryForSemanticStorage,
-  type BlueRepository,
-} from '@blue-labs/language';
-import { createDefaultMergingProcessor } from '../merge/utils/default.js';
+import { repository as blueRepository } from '@blue-repository/types';
+import type { blueIds as rawCoreBlueIds } from '@blue-repository/types/packages/core/blue-ids';
+import type { blueIds as rawConversationBlueIds } from '@blue-repository/types/packages/conversation/blue-ids';
+import type { blueIds as rawMyOsBlueIds } from '@blue-repository/types/packages/myos/blue-ids';
+import { type BlueRepository } from '@blue-labs/language';
 
-export const blueRepository = reindexRepositoryForSemanticStorage(
-  rawBlueRepository,
-  {
-    mergingProcessor: createDefaultMergingProcessor(),
-  },
-);
+export { blueRepository };
 
 export const blueIds = packageAliases<typeof rawCoreBlueIds>('core');
 export const conversationBlueIds =
@@ -25,9 +16,7 @@ function packageAliases<T extends Record<string, string>>(
 ): T {
   const pkg = (blueRepository as BlueRepository).packages[packageName];
   if (!pkg) {
-    throw new Error(
-      `Missing reindexed Blue repository package ${packageName}.`,
-    );
+    throw new Error(`Missing Blue repository package ${packageName}.`);
   }
   return pkg.aliases as T;
 }

--- a/libs/dsl-sdk/package.json
+++ b/libs/dsl-sdk/package.json
@@ -31,6 +31,6 @@
     "url": "git+https://github.com/bluecontract/blue-js.git"
   },
   "peerDependencies": {
-    "@blue-repository/types": ">=0.1.0 <1"
+    "@blue-repository/types": ">=0.1.0 <1 || >=1.0.0-rc.0 <2"
   }
 }

--- a/libs/dsl-sdk/package.json
+++ b/libs/dsl-sdk/package.json
@@ -31,6 +31,6 @@
     "url": "git+https://github.com/bluecontract/blue-js.git"
   },
   "peerDependencies": {
-    "@blue-repository/types": ">=0.1.0 <1 || >=1.0.0-rc.0 <2"
+    "@blue-repository/types": ">=1.0.0-rc.0 <2"
   }
 }

--- a/libs/dsl-sdk/src/lib/core/semantic-repository.ts
+++ b/libs/dsl-sdk/src/lib/core/semantic-repository.ts
@@ -1,19 +1,10 @@
-import { repository as rawBlueRepository } from '@blue-repository/types';
-import { blueIds as rawConversationBlueIds } from '@blue-repository/types/packages/conversation/blue-ids';
-import { blueIds as rawCoreBlueIds } from '@blue-repository/types/packages/core/blue-ids';
-import { blueIds as rawMyOsBlueIds } from '@blue-repository/types/packages/myos/blue-ids';
-import { createDefaultMergingProcessor } from '@blue-labs/document-processor';
-import {
-  reindexRepositoryForSemanticStorage,
-  type BlueRepository,
-} from '@blue-labs/language';
+import { repository as blueRepository } from '@blue-repository/types';
+import type { blueIds as rawConversationBlueIds } from '@blue-repository/types/packages/conversation/blue-ids';
+import type { blueIds as rawCoreBlueIds } from '@blue-repository/types/packages/core/blue-ids';
+import type { blueIds as rawMyOsBlueIds } from '@blue-repository/types/packages/myos/blue-ids';
+import { type BlueRepository } from '@blue-labs/language';
 
-export const blueRepository = reindexRepositoryForSemanticStorage(
-  rawBlueRepository,
-  {
-    mergingProcessor: createDefaultMergingProcessor(),
-  },
-);
+export { blueRepository };
 
 export const blueIds = packageAliases<typeof rawCoreBlueIds>('core');
 export const conversationBlueIds =
@@ -25,9 +16,7 @@ function packageAliases<T extends Record<string, string>>(
 ): T {
   const pkg = (blueRepository as BlueRepository).packages[packageName];
   if (!pkg) {
-    throw new Error(
-      `Missing reindexed Blue repository package ${packageName}.`,
-    );
+    throw new Error(`Missing Blue repository package ${packageName}.`);
   }
   return pkg.aliases as T;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@blue-quickjs/quickjs-runtime": "0.4.1",
         "@blue-quickjs/quickjs-wasm": "0.4.1",
         "@blue-quickjs/quickjs-wasm-constants": "0.4.1",
-        "@blue-repository/types": "0.30.0",
+        "@blue-repository/types": "1.0.0-rc.0",
         "@types/big.js": "6.2.2",
         "@types/js-yaml": "4.0.9",
         "base32.js": "0.1.0",
@@ -91,7 +91,7 @@
         "picomatch": "4.0.3"
       },
       "peerDependencies": {
-        "@blue-repository/types": ">=0.1.0 <1",
+        "@blue-repository/types": ">=0.1.0 <1 || >=1.0.0-rc.0 <2",
         "zod": "^3.20.0"
       }
     },
@@ -104,7 +104,7 @@
         "@blue-labs/language": "*"
       },
       "peerDependencies": {
-        "@blue-repository/types": ">=0.1.0 <1"
+        "@blue-repository/types": ">=0.1.0 <1 || >=1.0.0-rc.0 <2"
       }
     },
     "libs/language": {
@@ -1996,9 +1996,9 @@
       }
     },
     "node_modules/@blue-repository/types": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@blue-repository/types/-/types-0.30.0.tgz",
-      "integrity": "sha512-F3masgb38CSz9rwLNhxkOE6P/X09p+lLvS1/pOS4YGMuVZpQu38d8dO/M83fes40RJAJW6ksRN9tWHX3XlL2SQ==",
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@blue-repository/types/-/types-1.0.0-rc.0.tgz",
+      "integrity": "sha512-x/VYtuJT0ix0qBeZkNSL7gRi4InLOkN0Mf7lqjV08+EZUhcyEF5kyV2ZPO3Z2jd5daww3Pcun1Xpa92HxRwzbQ==",
       "license": "MIT",
       "peerDependencies": {
         "@blue-labs/language": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,7 +91,7 @@
         "picomatch": "4.0.3"
       },
       "peerDependencies": {
-        "@blue-repository/types": ">=0.1.0 <1 || >=1.0.0-rc.0 <2",
+        "@blue-repository/types": ">=1.0.0-rc.0 <2",
         "zod": "^3.20.0"
       }
     },
@@ -104,7 +104,7 @@
         "@blue-labs/language": "*"
       },
       "peerDependencies": {
-        "@blue-repository/types": ">=0.1.0 <1 || >=1.0.0-rc.0 <2"
+        "@blue-repository/types": ">=1.0.0-rc.0 <2"
       }
     },
     "libs/language": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@blue-quickjs/quickjs-runtime": "0.4.1",
     "@blue-quickjs/quickjs-wasm": "0.4.1",
     "@blue-quickjs/quickjs-wasm-constants": "0.4.1",
-    "@blue-repository/types": "0.30.0",
+    "@blue-repository/types": "1.0.0-rc.0",
     "@types/big.js": "6.2.2",
     "@types/js-yaml": "4.0.9",
     "base32.js": "0.1.0",


### PR DESCRIPTION
## Summary
- update @blue-repository/types to 1.0.0-rc.0
- use the published semantic repository artifact directly in document-processor and dsl-sdk
- remove runtime reindexRepositoryForSemanticStorage() from repository import paths
- allow the 1.0.0 RC range in package peer dependencies

## Verification
- npx nx test document-processor --skip-nx-cache
- npx nx test dsl-sdk --skip-nx-cache
- npx nx test language --skip-nx-cache
- npx tsc -p libs/document-processor/tsconfig.lib.json --noEmit
- npx tsc -p libs/dsl-sdk/tsconfig.lib.json --noEmit
- npx eslint libs/document-processor/src/repository/semantic-repository.ts libs/dsl-sdk/src/lib/core/semantic-repository.ts
- git diff --check

## Performance
- document-processor: Vitest Duration ~8.21s, wall ~15.47s
- dsl-sdk: Vitest Duration ~7.03s, wall ~17.01s
- dynamic import document-processor semantic-repository.ts: ~3.51ms