### PR TITLE
fix(language): match collection blueId type references

### DIFF
--- a/libs/document-processor/src/registry/__tests__/sequential-workflow-operation-processor.test.ts
+++ b/libs/document-processor/src/registry/__tests__/sequential-workflow-operation-processor.test.ts
@@ -13,6 +13,7 @@ import {
 import {
   blueIds as coreBlueIds,
   conversationBlueIds,
+  myosBlueIds,
 } from '../../repository/semantic-repository.js';
 
 const blue = createBlue();
@@ -186,6 +187,95 @@ describe('SequentialWorkflowOperationProcessor', () => {
     const counterNode = property(result.document, 'counter');
     expect(numericValue(counterNode)).toBe(5);
     expect(result.triggeredEvents.length).toBe(0);
+  });
+
+  it('cascades operation workflow emissions through triggered event handlers', async () => {
+    const processor = buildProcessor(blue);
+    const yaml = `name: Operation Reemit Cascade Doc
+contracts:
+  ownerChannel:
+    type: Conversation/Timeline Channel
+    timelineId: ${TIMELINE_ID}
+  triggered:
+    type: Core/Triggered Event Channel
+  myOsAdminUpdate:
+    type: Conversation/Operation
+    channel: ownerChannel
+    request:
+      type: List
+  myOsAdminUpdateImpl:
+    type: Conversation/Sequential Workflow Operation
+    operation: myOsAdminUpdate
+    steps:
+      - name: ReemitAdminUpdates
+        type: Conversation/JavaScript Code
+        code: |
+          const message = (event && event.message) || {};
+          const payload = message.request;
+          const payloadItems = payload && payload.items;
+          const events = Array.isArray(payload)
+            ? payload
+            : Array.isArray(payloadItems)
+              ? payloadItems
+              : payload
+                ? [payload]
+                : [];
+          return { events };
+  subscribeOnGrant:
+    type: Conversation/Sequential Workflow
+    channel: triggered
+    event:
+      type: MyOS/Single Document Permission Granted
+    steps:
+      - name: EmitSubscriptionMarker
+        type: Conversation/Trigger Event
+        event:
+          type: Conversation/Chat Message
+          message: Grant cascaded
+`;
+
+    const init = await expectOk(
+      processor.initializeDocument(blue.resolve(blue.yamlToNode(yaml))),
+    );
+    const storedBlueId = storedDocumentBlueId(init.document);
+    const event = operationRequestEvent({
+      operation: 'myOsAdminUpdate',
+      allowNewerVersion: false,
+      documentBlueId: storedBlueId,
+      request: [
+        {
+          type: 'MyOS/Single Document Permission Granted',
+          targetSessionId: 'buyer-card-session-1',
+          permissions: {
+            read: true,
+            singleOps: ['pay'],
+          },
+          inResponseTo: {
+            requestId: 'payment-source-access-grant',
+          },
+        },
+      ],
+    });
+
+    const result = await expectOk(
+      processor.processDocument(init.document.clone(), event),
+    );
+
+    const grantEvents = result.triggeredEvents.filter(
+      (emitted) =>
+        typeBlueId(emitted) ===
+        myosBlueIds['MyOS/Single Document Permission Granted'],
+    );
+    expect(grantEvents.length).toBe(1);
+
+    const chatEvents = result.triggeredEvents.filter(
+      (emitted) =>
+        typeBlueId(emitted) ===
+        conversationBlueIds['Conversation/Chat Message'],
+    );
+    expect(chatEvents.length).toBe(1);
+    const message = property(chatEvents[0], 'message').getValue();
+    expect(message).toBe('Grant cascaded');
   });
 
   it('applies Actor Policy rules for principal actors in browser sessions', async () => {
@@ -443,6 +533,37 @@ operations:
       processor.initializeDocument(buildOperationDocument()),
     );
     const event = operationRequestEvent({ request: 'oops' });
+
+    const result = await expectOk(
+      processor.processDocument(init.document.clone(), event),
+    );
+
+    const counterNode = property(result.document, 'counter');
+    expect(numericValue(counterNode)).toBe(0);
+  });
+
+  it('checks the full resolved request type instead of only its declared blueId', async () => {
+    const processor = buildProcessor(blue);
+    const init = await expectOk(
+      processor.initializeDocument(
+        blue.resolve(
+          buildOperationDocument({
+            requestTypeYaml: `type: List
+itemType:
+  type: Integer`,
+            changesetYaml: `- op: replace
+  path: /counter
+  val: 99`,
+          }),
+        ),
+      ),
+    );
+    const storedBlueId = storedDocumentBlueId(init.document);
+    const event = operationRequestEvent({
+      request: [1, 'same base List type, invalid item type'],
+      allowNewerVersion: false,
+      documentBlueId: storedBlueId,
+    });
 
     const result = await expectOk(
       processor.processDocument(init.document.clone(), event),

--- a/libs/document-processor/src/registry/processors/workflow/operation-matcher.ts
+++ b/libs/document-processor/src/registry/processors/workflow/operation-matcher.ts
@@ -130,43 +130,10 @@ export function isRequestTypeCompatible(
   ) {
     return false;
   }
-  try {
-    if (!blue.isTypeOfNode(requestPayload, requiredType)) {
-      if (
-        !matchesResolvedDeclaredTypeReference(
-          requestPayload,
-          requiredType,
-          blue,
-        )
-      ) {
-        return false;
-      }
-    }
-  } catch {
-    if (
-      !matchesResolvedDeclaredTypeReference(requestPayload, requiredType, blue)
-    ) {
-      return false;
-    }
-  }
-  return true;
-}
-
-function matchesResolvedDeclaredTypeReference(
-  requestPayload: BlueNode,
-  requiredType: BlueNode,
-  blue: Blue,
-): boolean {
-  if (!requiredType.isResolved()) {
+  if (!blue.isTypeOfNode(requestPayload, requiredType)) {
     return false;
   }
-
-  const requiredTypeBlueId = requiredType.getType()?.getBlueId();
-  return (
-    typeof requiredTypeBlueId === 'string' &&
-    requiredTypeBlueId.length > 0 &&
-    blue.isTypeOfBlueId(requestPayload, requiredTypeBlueId)
-  );
+  return true;
 }
 
 export function isPinnedDocumentAllowed(

--- a/libs/language/src/lib/utils/NodeTypeMatcher.ts
+++ b/libs/language/src/lib/utils/NodeTypeMatcher.ts
@@ -5,6 +5,15 @@ import { CompositeLimits, Limits, NO_LIMITS, PathLimits } from './limits';
 import { isBigNumber } from '../../utils/typeGuards/isBigNumber';
 import { NodeTypes } from './index';
 
+// Bare blueId matchers normally compare node identity. Inside collection
+// itemType/valueType declarations, the same bare blueId represents a type
+// reference, so values typed as that blueId should match.
+type BareBlueIdMatcherMode = 'identity' | 'type-reference';
+
+interface ValueComparisonOptions {
+  readonly bareBlueIdMatcherMode?: BareBlueIdMatcherMode;
+}
+
 export class NodeTypeMatcher {
   private blue: Blue;
 
@@ -21,8 +30,14 @@ export class NodeTypeMatcher {
     const pathLimits = PathLimits.fromNode(targetType);
     const compositeLimits = CompositeLimits.of(globalLimits, pathLimits);
 
-    const resolvedNode = this.extendAndResolve(node, compositeLimits);
-    const resolvedType = this.blue.resolve(targetType, compositeLimits);
+    let resolvedNode: BlueNode;
+    let resolvedType: BlueNode;
+    try {
+      resolvedNode = this.extendAndResolve(node, compositeLimits);
+      resolvedType = this.blue.resolve(targetType, compositeLimits);
+    } catch {
+      return false;
+    }
     const comparisonTargetType =
       this.expandSchemaOwnedTypeReferences(targetType);
 
@@ -134,6 +149,7 @@ export class NodeTypeMatcher {
     targetType: BlueNode,
     comparisonTargetType: BlueNode = targetType,
     limits: Limits = NO_LIMITS,
+    options: ValueComparisonOptions = {},
   ): boolean {
     const targetTypeType = targetType.getType();
     const isImplicitStructureMatch =
@@ -166,11 +182,13 @@ export class NodeTypeMatcher {
     const targetBlueId = targetType.getBlueId();
     if (!isImplicitStructureMatch && targetBlueId !== undefined) {
       if (this.isExplicitBlueIdMatcher(comparisonTargetType)) {
-        const nodeBlueId = node.getBlueId();
-        if (
-          nodeBlueId !== targetBlueId &&
-          !this.matchesCalculatedBlueId(node, targetBlueId)
-        ) {
+        if (options.bareBlueIdMatcherMode === 'type-reference') {
+          if (
+            !this.matchesBareBlueIdTypeReference(node, targetType, targetBlueId)
+          ) {
+            return false;
+          }
+        } else if (!this.matchesBareBlueIdIdentity(node, targetBlueId)) {
           return false;
         }
       } else {
@@ -262,10 +280,12 @@ export class NodeTypeMatcher {
               targetItemType,
               comparisonTargetItemType ?? targetItemType,
               limits,
+              'type-reference',
             ),
             targetItemType,
             comparisonTargetItemType ?? targetItemType,
             limits,
+            { bareBlueIdMatcherMode: 'type-reference' },
           )
         ) {
           return false;
@@ -309,10 +329,12 @@ export class NodeTypeMatcher {
               targetValueType,
               comparisonTargetValueType ?? targetValueType,
               limits,
+              'type-reference',
             ),
             targetValueType,
             comparisonTargetValueType ?? targetValueType,
             limits,
+            { bareBlueIdMatcherMode: 'type-reference' },
           )
         ) {
           return false;
@@ -328,10 +350,13 @@ export class NodeTypeMatcher {
     targetType: BlueNode,
     comparisonTargetType: BlueNode,
     limits: Limits,
+    bareBlueIdMatcherMode: BareBlueIdMatcherMode = 'identity',
   ): BlueNode {
     if (
       node.getType() !== undefined ||
-      this.isExplicitBlueIdMatcher(comparisonTargetType)
+      node.getBlueId() !== undefined ||
+      (bareBlueIdMatcherMode === 'identity' &&
+        this.isExplicitBlueIdMatcher(comparisonTargetType))
     ) {
       return node;
     }
@@ -397,6 +422,33 @@ export class NodeTypeMatcher {
         return false;
       }
     }
+  }
+
+  private matchesBareBlueIdIdentity(node: BlueNode, blueId: string): boolean {
+    const nodeBlueId = node.getBlueId();
+    return nodeBlueId === blueId || this.matchesCalculatedBlueId(node, blueId);
+  }
+
+  private matchesBareBlueIdTypeReference(
+    node: BlueNode,
+    targetType: BlueNode,
+    targetBlueId: string,
+  ): boolean {
+    const nodeType = node.getType();
+    if (nodeType) {
+      return NodeTypes.isSubtype(
+        nodeType,
+        targetType,
+        this.blue.getNodeProvider(),
+      );
+    }
+
+    const nodeBlueId = node.getBlueId();
+    if (nodeBlueId !== undefined) {
+      return this.matchesBareBlueIdIdentity(node, targetBlueId);
+    }
+
+    return false;
   }
 
   private toPlainBlueNode(node: BlueNode): BlueNode {

--- a/libs/language/src/lib/utils/__tests__/NodeTypeMatcher.test.ts
+++ b/libs/language/src/lib/utils/__tests__/NodeTypeMatcher.test.ts
@@ -102,6 +102,29 @@ function buildMatcherRepository(): BlueRepository {
         },
       },
     },
+    {
+      alias: 'Matcher/Operation Permission Set',
+      name: 'Operation Permission Set',
+      json: {
+        name: 'Operation Permission Set',
+        read: { type: 'Boolean' },
+        singleOps: {
+          type: 'List',
+          itemType: 'Text',
+        },
+      },
+    },
+    {
+      alias: 'Matcher/Permission Granted Event',
+      name: 'Permission Granted Event',
+      json: {
+        name: 'Permission Granted Event',
+        permissions: {
+          type: 'Matcher/Operation Permission Set',
+        },
+        targetSessionId: { type: 'Text' },
+      },
+    },
   ] as const;
 
   const aliases: Record<string, string> = {};
@@ -455,6 +478,7 @@ items:
     const blue = new Blue({ nodeProvider });
     const matcher = new NodeTypeMatcher(blue);
 
+    const implicitStringListNode = blue.jsonValueToNode(['first', 'second']);
     const implicitListNode = blue.jsonValueToNode([1, 2, 3]);
     const implicitDictNode = blue.jsonValueToNode({
       first: 1,
@@ -466,6 +490,7 @@ itemType: Text`);
     const dictMatcher = blue.yamlToNode(`type: Dictionary
 valueType: Text`);
 
+    expect(matcher.matchesType(implicitStringListNode, listMatcher)).toBe(true);
     expect(matcher.matchesType(implicitListNode, listMatcher)).toBe(false);
     expect(matcher.matchesType(implicitDictNode, dictMatcher)).toBe(false);
   });
@@ -669,5 +694,38 @@ read:
     expect(
       matcher.matchesType(workerAgencyGrant, workerAgencyGrant.getType()!),
     ).toBe(true);
+  });
+
+  test('resolved schema filters treat nested collection itemType blueIds as type constraints', () => {
+    const blue = new Blue({ repositories: [matcherRepository] });
+    const matcher = new NodeTypeMatcher(blue);
+
+    const event = blue.resolve(
+      blue.jsonValueToNode({
+        type: 'Matcher/Permission Granted Event',
+        targetSessionId: 'buyer-card-session-1',
+        permissions: {
+          read: true,
+          singleOps: ['pay'],
+        },
+      }),
+    );
+    const wrongItemTypeEvent = blue.jsonValueToNode({
+      type: 'Matcher/Permission Granted Event',
+      targetSessionId: 'buyer-card-session-1',
+      permissions: {
+        read: true,
+        singleOps: ['pay', 123],
+      },
+    });
+    const resolvedPattern = blue.resolve(
+      blue.yamlToNode('type: Matcher/Permission Granted Event'),
+    );
+
+    expect(resolvedPattern.isResolved()).toBe(true);
+    expect(matcher.matchesType(event, resolvedPattern)).toBe(true);
+    expect(matcher.matchesType(wrongItemTypeEvent, resolvedPattern)).toBe(
+      false,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Treat bare blueId matchers under itemType/valueType as type references instead of node identity checks.
- Keep bare blueId identity semantics outside collection type declarations.
- Add resolved-schema matcher coverage, including a negative nested itemType case.
- Simplify document-processor operation request compatibility to rely on blue.isTypeOfNode.

## Verification
- npx vitest run libs/language/src/lib/utils/__tests__/NodeTypeMatcher.test.ts
- npx vitest run libs/document-processor/src/registry/__tests__/sequential-workflow-operation-processor.test.ts
- npx tsc -p libs/language/tsconfig.lib.json --noEmit
- npx tsc -p libs/language/tsconfig.spec.json --noEmit
- npx tsc -p libs/document-processor/tsconfig.lib.json --noEmit
- npx eslint libs/document-processor libs/language/src/lib/utils/NodeTypeMatcher.ts libs/language/src/lib/utils/__tests__/NodeTypeMatcher.test.ts
- npx nx test language --skip-nx-cache
- npx nx test document-processor --skip-nx-cache