### PR TITLE
chore(deps): update blue repository types to 1.0.0

### DIFF
--- a/libs/document-processor/package.json
+++ b/libs/document-processor/package.json
@@ -35,7 +35,7 @@
     "url": "git+https://github.com/bluecontract/blue-js.git"
   },
   "peerDependencies": {
-    "@blue-repository/types": ">=1.0.0-rc.0 <2",
+    "@blue-repository/types": ">=1.0.0 <2",
     "zod": "^3.20.0"
   }
 }

--- a/libs/dsl-sdk/package.json
+++ b/libs/dsl-sdk/package.json
@@ -31,6 +31,6 @@
     "url": "git+https://github.com/bluecontract/blue-js.git"
   },
   "peerDependencies": {
-    "@blue-repository/types": ">=1.0.0-rc.0 <2"
+    "@blue-repository/types": ">=1.0.0 <2"
   }
 }

--- a/libs/language/src/lib/__tests__/Blue.collectionTyping.characterization.test.ts
+++ b/libs/language/src/lib/__tests__/Blue.collectionTyping.characterization.test.ts
@@ -29,10 +29,7 @@ function inspectRoundTrip(blue: Blue, value: unknown) {
   };
 }
 
-// The installed @blue-repository/types package still uses pre-semantic storage
-// keys. Re-enable these characterization tests after that package is reindexed
-// to strict semantic BlueIds.
-describe.skip('collection-backed Blue repository type characterization', () => {
+describe('collection-backed Blue repository type characterization', () => {
   it('shows that the blanket dict/list hypothesis is false', () => {
     const blue = createBlue();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@blue-quickjs/quickjs-runtime": "0.4.1",
         "@blue-quickjs/quickjs-wasm": "0.4.1",
         "@blue-quickjs/quickjs-wasm-constants": "0.4.1",
-        "@blue-repository/types": "1.0.0-rc.0",
+        "@blue-repository/types": "1.0.0",
         "@types/big.js": "6.2.2",
         "@types/js-yaml": "4.0.9",
         "base32.js": "0.1.0",
@@ -91,7 +91,7 @@
         "picomatch": "4.0.3"
       },
       "peerDependencies": {
-        "@blue-repository/types": ">=1.0.0-rc.0 <2",
+        "@blue-repository/types": ">=1.0.0 <2",
         "zod": "^3.20.0"
       }
     },
@@ -104,7 +104,7 @@
         "@blue-labs/language": "4.0.0"
       },
       "peerDependencies": {
-        "@blue-repository/types": ">=1.0.0-rc.0 <2"
+        "@blue-repository/types": ">=1.0.0 <2"
       }
     },
     "libs/language": {
@@ -1996,9 +1996,9 @@
       }
     },
     "node_modules/@blue-repository/types": {
-      "version": "1.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@blue-repository/types/-/types-1.0.0-rc.0.tgz",
-      "integrity": "sha512-x/VYtuJT0ix0qBeZkNSL7gRi4InLOkN0Mf7lqjV08+EZUhcyEF5kyV2ZPO3Z2jd5daww3Pcun1Xpa92HxRwzbQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@blue-repository/types/-/types-1.0.0.tgz",
+      "integrity": "sha512-6lGScqC6d9sJUwcaXEHE44quIID+pq8uWMqeoS8r/2Dm86AjKH/XUaSO9YgWuR1trRWD/Kad6U87a9Q8SgMeJg==",
       "license": "MIT",
       "peerDependencies": {
         "@blue-labs/language": "*",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@blue-quickjs/quickjs-runtime": "0.4.1",
     "@blue-quickjs/quickjs-wasm": "0.4.1",
     "@blue-quickjs/quickjs-wasm-constants": "0.4.1",
-    "@blue-repository/types": "1.0.0-rc.0",
+    "@blue-repository/types": "1.0.0",
     "@types/big.js": "6.2.2",
     "@types/js-yaml": "4.0.9",
     "base32.js": "0.1.0",


### PR DESCRIPTION
## Summary
- update @blue-repository/types from 1.0.0-rc.0 to 1.0.0
- update document-processor and dsl-sdk peer ranges to require stable @blue-repository/types >=1.0.0 <2
- enable the repository collection typing characterization test now that stable types use Language v4 BlueId calculation

## Verification
- npx tsc -p libs/language/tsconfig.lib.json --noEmit
- npx tsc -p libs/document-processor/tsconfig.lib.json --noEmit
- npx tsc -p libs/dsl-sdk/tsconfig.lib.json --noEmit
- npx vitest run --config libs/language/vite.config.ts
- npx vitest run --config libs/document-processor/vite.config.ts
- npx vitest run --config libs/dsl-sdk/vite.config.ts
- npx eslint libs/language/src/lib/__tests__/Blue.collectionTyping.characterization.test.ts
- git diff --check

Note: full eslint over libs/language libs/document-processor libs/dsl-sdk was attempted, but it hit Node heap limits / did not complete in a useful time locally. The changed TS test file was linted directly.
