### PR TITLE
Use QuickJS workflow DV limits

### DIFF
--- a/libs/document-processor/package.json
+++ b/libs/document-processor/package.json
@@ -21,9 +21,9 @@
   "dependencies": {
     "@blue-labs/language": "4.0.1",
     "@blue-labs/shared-utils": "4.0.1",
-    "@blue-quickjs/abi-manifest": "0.4.1",
-    "@blue-quickjs/dv": "0.4.1",
-    "@blue-quickjs/quickjs-runtime": "0.4.1",
+    "@blue-quickjs/abi-manifest": "0.4.2-rc.0",
+    "@blue-quickjs/dv": "0.4.2-rc.0",
+    "@blue-quickjs/quickjs-runtime": "0.4.2-rc.0",
     "picomatch": "4.0.3"
   },
   "license": "MIT",

--- a/libs/document-processor/src/util/expression/__tests__/quickjs-evaluator.test.ts
+++ b/libs/document-processor/src/util/expression/__tests__/quickjs-evaluator.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
+import { encodeDv } from '@blue-quickjs/dv';
 
 import {
   QuickJSEvaluator,
+  WORKFLOW_DV_LIMITS,
   type QuickJSBindings,
 } from '../quickjs-evaluator.js';
 
@@ -124,6 +126,50 @@ describe('QuickJSEvaluator', () => {
     expect(result).toBe(12);
   });
 
+  it('returns workflow output just below the workflow DV cap', async () => {
+    const evaluator = new QuickJSEvaluator();
+    const payload = buildStringArrayPayload(
+      WORKFLOW_DV_LIMITS.maxEncodedBytes - 1,
+    );
+    const result = (await evaluator.evaluate({
+      code: buildStringArrayReturnCode(payload),
+      wasmGasLimit: 20_000_000n,
+    })) as string[];
+
+    expect(encodeDv(result, { limits: WORKFLOW_DV_LIMITS })).toHaveLength(
+      WORKFLOW_DV_LIMITS.maxEncodedBytes - 1,
+    );
+    expect(result).toHaveLength(payload.fullChunks + 1);
+  });
+
+  it('returns workflow output exactly at the workflow DV cap', async () => {
+    const evaluator = new QuickJSEvaluator();
+    const payload = buildStringArrayPayload(WORKFLOW_DV_LIMITS.maxEncodedBytes);
+    const result = (await evaluator.evaluate({
+      code: buildStringArrayReturnCode(payload),
+      wasmGasLimit: 20_000_000n,
+    })) as string[];
+
+    expect(encodeDv(result, { limits: WORKFLOW_DV_LIMITS })).toHaveLength(
+      WORKFLOW_DV_LIMITS.maxEncodedBytes,
+    );
+    expect(result).toHaveLength(payload.fullChunks + 1);
+  });
+
+  it('rejects workflow output just above the workflow DV cap', async () => {
+    const evaluator = new QuickJSEvaluator();
+    const payload = buildStringArrayPayload(
+      WORKFLOW_DV_LIMITS.maxEncodedBytes + 1,
+    );
+
+    await expect(
+      evaluator.evaluate({
+        code: buildStringArrayReturnCode(payload),
+        wasmGasLimit: 20_000_000n,
+      }),
+    ).rejects.toThrow(/encoded DV exceeds maxEncodedBytes/i);
+  });
+
   it('exposes current contract bindings to the evaluated code', async () => {
     const evaluator = new QuickJSEvaluator();
 
@@ -241,3 +287,86 @@ describe('QuickJSEvaluator', () => {
     ).rejects.toThrow(/emit binding must be a function/);
   });
 });
+
+const WORKFLOW_CHUNK_BYTES = 200_000;
+
+interface StringArrayPayload {
+  readonly fullChunks: number;
+  readonly finalBytes: number;
+}
+
+function buildStringArrayReturnCode(payload: StringArrayPayload): string {
+  return `
+    const chunks = Array.from(
+      { length: ${payload.fullChunks} },
+      () => 'x'.repeat(${WORKFLOW_CHUNK_BYTES})
+    );
+    chunks.push('x'.repeat(${payload.finalBytes}));
+    return chunks;
+  `;
+}
+
+function buildStringArrayPayload(
+  targetEncodedBytes: number,
+): StringArrayPayload {
+  for (let fullChunks = 0; fullChunks < 200; fullChunks += 1) {
+    const fullChunkBytes = fullChunks * cborStringBytes(WORKFLOW_CHUNK_BYTES);
+    for (const finalHeaderBytes of [1, 2, 3, 5]) {
+      const finalBytes =
+        targetEncodedBytes -
+        cborArrayHeaderBytes(fullChunks + 1) -
+        fullChunkBytes -
+        finalHeaderBytes;
+      if (
+        finalBytes >= 0 &&
+        finalBytes <= WORKFLOW_CHUNK_BYTES &&
+        cborStringHeaderBytes(finalBytes) === finalHeaderBytes
+      ) {
+        const candidate = [
+          ...Array.from({ length: fullChunks }, () =>
+            'x'.repeat(WORKFLOW_CHUNK_BYTES),
+          ),
+          'x'.repeat(finalBytes),
+        ];
+        if (
+          encodeDv(candidate, {
+            limits: {
+              ...WORKFLOW_DV_LIMITS,
+              maxEncodedBytes: WORKFLOW_DV_LIMITS.maxEncodedBytes * 2,
+            },
+          }).length === targetEncodedBytes
+        ) {
+          return { fullChunks, finalBytes };
+        }
+      }
+    }
+  }
+  throw new Error(`Unable to build payload for ${targetEncodedBytes} bytes`);
+}
+
+function cborArrayHeaderBytes(length: number): number {
+  if (length < 24) {
+    return 1;
+  }
+  if (length <= 0xff) {
+    return 2;
+  }
+  return 3;
+}
+
+function cborStringBytes(length: number): number {
+  return cborStringHeaderBytes(length) + length;
+}
+
+function cborStringHeaderBytes(length: number): number {
+  if (length < 24) {
+    return 1;
+  }
+  if (length <= 0xff) {
+    return 2;
+  }
+  if (length <= 0xffff) {
+    return 3;
+  }
+  return 5;
+}

--- a/libs/document-processor/src/util/expression/quickjs-evaluator.ts
+++ b/libs/document-processor/src/util/expression/quickjs-evaluator.ts
@@ -9,6 +9,10 @@ import { DEFAULT_WASM_GAS_LIMIT } from './quickjs-config.js';
 import { HOST_V1_MANIFEST, HOST_V1_HASH } from '@blue-quickjs/abi-manifest';
 
 const HOST_CALL_UNITS = 1;
+export const WORKFLOW_DV_LIMITS = {
+  ...DV_LIMIT_DEFAULTS,
+  maxEncodedBytes: 16 * 1024 * 1024,
+} as const;
 
 type DocumentBinding = ((pointer?: unknown) => unknown) & {
   canonical?: (pointer?: unknown) => unknown;
@@ -107,6 +111,8 @@ export class QuickJSEvaluator {
         gasLimit,
         manifest: HOST_V1_MANIFEST,
         handlers: this.handlers,
+        dvLimits: WORKFLOW_DV_LIMITS,
+        outputDvLimits: WORKFLOW_DV_LIMITS,
       });
 
       if (wasmGasLimit !== undefined && onWasmGasUsed) {
@@ -218,7 +224,7 @@ function assertSupportedBindings(bindings: QuickJSBindings): void {
 function normalizeInputDv(value: unknown, fallback: DV, label: string): DV {
   const resolved = value === undefined ? fallback : value;
   try {
-    validateDv(resolved, { limits: DV_LIMIT_DEFAULTS });
+    validateDv(resolved, { limits: WORKFLOW_DV_LIMITS });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new TypeError(

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,11 @@
         "libs/shared/*"
       ],
       "dependencies": {
-        "@blue-quickjs/abi-manifest": "0.4.1",
-        "@blue-quickjs/dv": "0.4.1",
-        "@blue-quickjs/quickjs-runtime": "0.4.1",
-        "@blue-quickjs/quickjs-wasm": "0.4.1",
-        "@blue-quickjs/quickjs-wasm-constants": "0.4.1",
+        "@blue-quickjs/abi-manifest": "0.4.2-rc.0",
+        "@blue-quickjs/dv": "0.4.2-rc.0",
+        "@blue-quickjs/quickjs-runtime": "0.4.2-rc.0",
+        "@blue-quickjs/quickjs-wasm": "0.4.2-rc.0",
+        "@blue-quickjs/quickjs-wasm-constants": "0.4.2-rc.0",
         "@blue-repository/types": "1.0.0",
         "@types/big.js": "6.2.2",
         "@types/js-yaml": "4.0.9",
@@ -85,9 +85,9 @@
       "dependencies": {
         "@blue-labs/language": "4.0.1",
         "@blue-labs/shared-utils": "4.0.1",
-        "@blue-quickjs/abi-manifest": "0.4.1",
-        "@blue-quickjs/dv": "0.4.1",
-        "@blue-quickjs/quickjs-runtime": "0.4.1",
+        "@blue-quickjs/abi-manifest": "0.4.2-rc.0",
+        "@blue-quickjs/dv": "0.4.2-rc.0",
+        "@blue-quickjs/quickjs-runtime": "0.4.2-rc.0",
         "picomatch": "4.0.3"
       },
       "peerDependencies": {
@@ -1946,50 +1946,50 @@
       "link": true
     },
     "node_modules/@blue-quickjs/abi-manifest": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@blue-quickjs/abi-manifest/-/abi-manifest-0.4.1.tgz",
-      "integrity": "sha512-7U2YbRKaYzP6YzXaEUWotxyL4exYqnVFcDgnJxjqzQ7bfTbrL3V17PlPb0xbEO5iAJH6stEVW7Aerj+EZY26tw==",
+      "version": "0.4.2-rc.0",
+      "resolved": "https://registry.npmjs.org/@blue-quickjs/abi-manifest/-/abi-manifest-0.4.2-rc.0.tgz",
+      "integrity": "sha512-FIylrPRd3iF/qWT6yRMVcJC/zaZJH3y7EvE09ir6LozLsIU5f0sl7hXKYlzFXmW7qrMGP2jQXqLnCoWh8amtMw==",
       "license": "MIT",
       "dependencies": {
-        "@blue-quickjs/dv": "0.4.1",
+        "@blue-quickjs/dv": "0.4.2-rc.0",
         "@noble/hashes": "^1.5.0",
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@blue-quickjs/dv": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@blue-quickjs/dv/-/dv-0.4.1.tgz",
-      "integrity": "sha512-9aNDR13QDGf8lsMyEBH/e5jDtGmcm+Sj+RaVo7GvAfrCh3PeAIvMBx1hA+RwDCg6pharB5xrsubGc1ADgwfpsQ==",
+      "version": "0.4.2-rc.0",
+      "resolved": "https://registry.npmjs.org/@blue-quickjs/dv/-/dv-0.4.2-rc.0.tgz",
+      "integrity": "sha512-yX44JjGgt+qU2IW8tKiHevZE6nqC4W3vTstyXGpftETLgR5SeGRiQNAFYwvmbtwmI+iSFL+i+z66Y34s604PQg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@blue-quickjs/quickjs-runtime": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@blue-quickjs/quickjs-runtime/-/quickjs-runtime-0.4.1.tgz",
-      "integrity": "sha512-P63Y/oH/aYQYDtra5AYaLkUDJB0L/UJNr5WihJpLBi8gxj4dWvYcA3rbWFykkjHtlFttZBTl6B+EInhmjjOvhA==",
+      "version": "0.4.2-rc.0",
+      "resolved": "https://registry.npmjs.org/@blue-quickjs/quickjs-runtime/-/quickjs-runtime-0.4.2-rc.0.tgz",
+      "integrity": "sha512-6+EpVkkz1aTqYS5rMm7V7SDZFMp5F5o8aAiC9exENFBL022T1kvSYOICqEhEElzY0gREpR+IjAU0yrAvrSIXiw==",
       "license": "MIT",
       "dependencies": {
-        "@blue-quickjs/abi-manifest": "0.4.1",
-        "@blue-quickjs/dv": "0.4.1",
-        "@blue-quickjs/quickjs-wasm": "0.4.1",
+        "@blue-quickjs/abi-manifest": "0.4.2-rc.0",
+        "@blue-quickjs/dv": "0.4.2-rc.0",
+        "@blue-quickjs/quickjs-wasm": "0.4.2-rc.0",
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@blue-quickjs/quickjs-wasm": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@blue-quickjs/quickjs-wasm/-/quickjs-wasm-0.4.1.tgz",
-      "integrity": "sha512-4j1o5I0Q1tiyVpTTDSjdh+cUW1zMTUmbIjVDqBIMhPNZLFunD8zXk3EIVouJYYMUJxPrp3u5H8QqPYd0r9yuvA==",
+      "version": "0.4.2-rc.0",
+      "resolved": "https://registry.npmjs.org/@blue-quickjs/quickjs-wasm/-/quickjs-wasm-0.4.2-rc.0.tgz",
+      "integrity": "sha512-FzjP7MoQQPTIbsAnqimKhBTrlvNa04B8aRzssPUCCorEBr9jC0Bl8fue471GHV6uCxgQoydLEppnew1N651wVg==",
       "license": "MIT",
       "dependencies": {
-        "@blue-quickjs/quickjs-wasm-constants": "0.4.1"
+        "@blue-quickjs/quickjs-wasm-constants": "0.4.2-rc.0"
       }
     },
     "node_modules/@blue-quickjs/quickjs-wasm-constants": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@blue-quickjs/quickjs-wasm-constants/-/quickjs-wasm-constants-0.4.1.tgz",
-      "integrity": "sha512-T472cAiHY4iZkE/U+xOUlpDc1xMK9DCqyhIPFwv6pF70P5meaHo5rSQ7x+MsfdhrO6+OWDNiAQB9GrXnGX/Ccg==",
+      "version": "0.4.2-rc.0",
+      "resolved": "https://registry.npmjs.org/@blue-quickjs/quickjs-wasm-constants/-/quickjs-wasm-constants-0.4.2-rc.0.tgz",
+      "integrity": "sha512-2Z/riIZMOpOyWYlSy8wI52sI7uaSKLwVCsCLBtEQFfT0ETNGZ2HFqoSDY6wZQ2HXkEM/RfNQyQ/vX5kk8FeWEw==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -49,11 +49,11 @@
     "libs/shared/*"
   ],
   "dependencies": {
-    "@blue-quickjs/abi-manifest": "0.4.1",
-    "@blue-quickjs/dv": "0.4.1",
-    "@blue-quickjs/quickjs-runtime": "0.4.1",
-    "@blue-quickjs/quickjs-wasm": "0.4.1",
-    "@blue-quickjs/quickjs-wasm-constants": "0.4.1",
+    "@blue-quickjs/abi-manifest": "0.4.2-rc.0",
+    "@blue-quickjs/dv": "0.4.2-rc.0",
+    "@blue-quickjs/quickjs-runtime": "0.4.2-rc.0",
+    "@blue-quickjs/quickjs-wasm": "0.4.2-rc.0",
+    "@blue-quickjs/quickjs-wasm-constants": "0.4.2-rc.0",
     "@blue-repository/types": "1.0.0",
     "@types/big.js": "6.2.2",
     "@types/js-yaml": "4.0.9",


### PR DESCRIPTION
## Summary
- bump @blue-quickjs packages to 0.4.2-rc.0
- opt document-processor workflow input/output evaluation into the 16 MiB deterministic workflow DV cap
- keep the default/global DV cap unchanged outside workflow evaluation
- add boundary-focused evaluator tests for just-below, exactly-at, and just-above the workflow cap

## Validation
- npm install --ignore-scripts
- npx vitest run libs/document-processor/src/util/expression/__tests__/quickjs-evaluator.test.ts
- npx prettier --check package.json libs/document-processor/package.json libs/document-processor/src/util/expression/quickjs-evaluator.ts libs/document-processor/src/util/expression/__tests__/quickjs-evaluator.test.ts
- npx nx typecheck document-processor
- npx nx lint document-processor
- npx nx build document-processor
- npx nx affected --exclude @blue-js/monorepo -t lint test build --base=origin/develop --head=HEAD
