### PR TITLE
- Add support for handling cyclic BlueIds in repository generator

### DIFF
--- a/libs/language/src/lib/provider/RepositoryBasedNodeProvider.ts
+++ b/libs/language/src/lib/provider/RepositoryBasedNodeProvider.ts
@@ -6,6 +6,11 @@ import { BlueRepository } from '../types/BlueRepository';
 import type { MergingProcessor } from '../merge/MergingProcessor';
 import { canonicalizeRepositoryContent } from '../repository/RepositoryContentCanonicalizer';
 
+interface IndexedRepositoryContent {
+  index: number;
+  content: JsonBlueValue;
+}
+
 /**
  * A NodeProvider that indexes content from trusted BlueRepository definitions.
  * Similar to Java's ClasspathBasedNodeProvider but for repository content.
@@ -20,6 +25,7 @@ export class RepositoryBasedNodeProvider extends PreloadedNodeProvider {
     _options: { mergingProcessor?: MergingProcessor } = {},
   ) {
     super();
+    void _options;
 
     const aliasMappings =
       RepositoryBasedNodeProvider.collectAliasMappings(repositories);
@@ -47,19 +53,75 @@ export class RepositoryBasedNodeProvider extends PreloadedNodeProvider {
   }
 
   private loadRepositories(repositories: BlueRepository[]): void {
+    const standaloneContent: Array<{
+      providedBlueId: string;
+      content: JsonBlueValue;
+    }> = [];
+    const cyclicContent = new Map<string, IndexedRepositoryContent[]>();
+
     for (const repository of repositories) {
       Object.values(repository.packages).forEach((pkg) => {
         for (const [providedBlueId, content] of Object.entries(pkg.contents)) {
-          const canonicalContent = canonicalizeRepositoryContent(content);
-          this.storeContent(
-            providedBlueId,
-            canonicalContent,
-            Array.isArray(canonicalContent),
-          );
-          this.addContentNames(providedBlueId, canonicalContent);
+          const cyclicId =
+            RepositoryBasedNodeProvider.parseCyclicBlueId(providedBlueId);
+          if (!cyclicId) {
+            standaloneContent.push({ providedBlueId, content });
+            continue;
+          }
+          const group = cyclicContent.get(cyclicId.baseBlueId) ?? [];
+          group.push({ index: cyclicId.index, content });
+          cyclicContent.set(cyclicId.baseBlueId, group);
         }
       });
     }
+
+    standaloneContent.forEach(({ content, providedBlueId }) => {
+      const canonicalContent = canonicalizeRepositoryContent(content);
+      this.storeContent(
+        providedBlueId,
+        canonicalContent,
+        Array.isArray(canonicalContent),
+      );
+      this.addContentNames(providedBlueId, canonicalContent);
+    });
+
+    for (const [baseBlueId, entries] of cyclicContent) {
+      const contents = RepositoryBasedNodeProvider.toDenseCyclicContent(
+        baseBlueId,
+        entries,
+      );
+      const canonicalContent = canonicalizeRepositoryContent(contents);
+      this.storeContent(baseBlueId, canonicalContent, true);
+      this.addContentNames(baseBlueId, canonicalContent);
+    }
+  }
+
+  private static parseCyclicBlueId(
+    blueId: string,
+  ): { baseBlueId: string; index: number } | null {
+    const match = /^(.*)#(\d+)$/.exec(blueId);
+    if (!match?.[1] || match[2] === undefined) {
+      return null;
+    }
+    return {
+      baseBlueId: match[1],
+      index: Number.parseInt(match[2], 10),
+    };
+  }
+
+  private static toDenseCyclicContent(
+    baseBlueId: string,
+    entries: IndexedRepositoryContent[],
+  ): JsonBlueValue[] {
+    const sorted = [...entries].sort((a, b) => a.index - b.index);
+    return sorted.map((entry, expectedIndex) => {
+      if (entry.index !== expectedIndex) {
+        throw new Error(
+          `Cyclic repository content for ${baseBlueId} is missing index ${expectedIndex}.`,
+        );
+      }
+      return entry.content;
+    });
   }
 
   private addContentNames(blueId: string, content: JsonBlueValue): void {

--- a/libs/language/src/lib/provider/__tests__/RepositoryBasedNodeProvider.test.ts
+++ b/libs/language/src/lib/provider/__tests__/RepositoryBasedNodeProvider.test.ts
@@ -447,4 +447,74 @@ describe('RepositoryBasedNodeProvider', () => {
       'SingletonLoopConsumer',
     );
   });
+
+  it('groups cyclic repository content by master BlueId', () => {
+    const masterId = 'cyclic-master';
+    const firstId = `${masterId}#0`;
+    const secondId = `${masterId}#1`;
+    const typesMeta = {
+      [firstId]: {
+        status: 'stable' as const,
+        name: 'First',
+        versions: [
+          {
+            repositoryVersionIndex: 0,
+            typeBlueId: firstId,
+            attributesAdded: [],
+          },
+        ],
+      },
+      [secondId]: {
+        status: 'stable' as const,
+        name: 'Second',
+        versions: [
+          {
+            repositoryVersionIndex: 0,
+            typeBlueId: secondId,
+            attributesAdded: [],
+          },
+        ],
+      },
+    };
+
+    const repository = {
+      name: 'test.repo',
+      repositoryVersions: ['R0'],
+      packages: {
+        test: {
+          name: 'test',
+          aliases: {
+            'test/First': firstId,
+            'test/Second': secondId,
+          },
+          typesMeta,
+          contents: {
+            [firstId]: {
+              name: 'First',
+              ref: { type: { blueId: 'this#1' } },
+            },
+            [secondId]: {
+              name: 'Second',
+              ref: { type: { blueId: 'this#0' } },
+            },
+          },
+          schemas: {},
+        },
+      },
+    };
+
+    const provider = new RepositoryBasedNodeProvider([repository]);
+    const first = provider.fetchByBlueId(firstId)?.[0];
+    const second = provider.fetchByBlueId(secondId)?.[0];
+
+    expect(first?.getBlueId()).toBeUndefined();
+    expect(second?.getBlueId()).toBeUndefined();
+    expect(first?.getProperties()?.ref?.getType()?.getBlueId()).toEqual(
+      secondId,
+    );
+    expect(second?.getProperties()?.ref?.getType()?.getBlueId()).toEqual(
+      firstId,
+    );
+    expect(provider.findNodeByName('First')?.getBlueId()).toBeUndefined();
+  });
 });

--- a/libs/repository-generator/README.md
+++ b/libs/repository-generator/README.md
@@ -43,7 +43,8 @@ console.log(result.document); // BlueRepositoryDocument
   - Breaking changes (non-optional diffs) are rejected.
   - Stable → dev downgrade is rejected.
   - Stable types cannot depend on dev types.
-- Dependency graph is topo-sorted; aliases are validated and cycles rejected.
+- Dependency graph is processed in dependency order; strongly connected type
+  groups are hashed with `this`/`this#<index>` cyclic references.
 - Output is deterministic (sorted packages/types/versions); repo BlueId covers the packages subtree only.
 
 ## Tests

--- a/libs/repository-generator/src/__tests__/generateRepository.test.ts
+++ b/libs/repository-generator/src/__tests__/generateRepository.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import yaml from 'js-yaml';
 import { Blue, createNodeProvider } from '@blue-labs/language';
 import type { JsonValue } from '@blue-labs/shared-utils';
 import { generateRepository } from '../lib/generateRepository';
@@ -749,6 +750,74 @@ text:
     expect(second.yaml).toEqual(first.yaml);
   });
 
+  it('preserves published BlueIds and stored content for unchanged existing types', () => {
+    const repoRoot = createRepo();
+    writeType(
+      repoRoot,
+      'Sandbox',
+      'Base.blue',
+      `
+name: Base
+text:
+  type: Text
+description: Saved order
+`,
+    );
+
+    const historicalTypeBlueId = '6CtkPkPVtmiQJJienGdzvZf2qGTRQntLXfh8PYeMfxBX';
+    const historicalRepoBlueId = 'sUk1iHFrf7UQXAMeQvWRyvYVxxStUjfARaE5e4EgDKv';
+    const previousYaml = yaml.dump(
+      {
+        name: 'Blue Repository',
+        packages: [
+          {
+            name: 'Sandbox',
+            types: [
+              {
+                status: 'stable',
+                content: {
+                  name: 'Base',
+                  description: 'Saved order',
+                  text: {
+                    type: {
+                      blueId: 'DLRQwz7MQeCrzjy9bohPNwtCxKEBbKaMK65KBrwjfG6K',
+                    },
+                  },
+                },
+                versions: [
+                  {
+                    repositoryVersionIndex: 0,
+                    typeBlueId: historicalTypeBlueId,
+                    attributesAdded: [],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        repositoryVersions: [historicalRepoBlueId],
+      },
+      { lineWidth: -1 },
+    );
+    persistRepository(repoRoot, previousYaml);
+
+    const result = generateRepository({
+      repoRoot,
+      blueRepositoryPath: path.join(repoRoot, BLUE_REPOSITORY),
+    });
+    const typeMetadata = result.document.packages[0]?.types[0];
+
+    expect(result.changed).toBe(false);
+    expect(result.currentRepoBlueId).toBe(historicalRepoBlueId);
+    expect(result.yaml).toEqual(readRepositoryFile(repoRoot));
+    expect(typeMetadata?.versions[0]?.typeBlueId).toBe(historicalTypeBlueId);
+    expect(Object.keys(typeMetadata?.content ?? {})).toEqual([
+      'name',
+      'description',
+      'text',
+    ]);
+  });
+
   it('rejects breaking changes to stable types', () => {
     const repoRoot = createRepo();
     writeType(
@@ -1234,7 +1303,7 @@ feature:
     ).toThrow(/depends on a dev type/);
   });
 
-  it('detects circular dependencies', () => {
+  it('supports circular dependencies with combined BlueIds', () => {
     const repoRoot = createRepo();
     writeType(
       repoRoot,
@@ -1257,12 +1326,97 @@ ref:
 `,
     );
 
-    expect(() =>
-      generateRepository({
-        repoRoot,
-        blueRepositoryPath: path.join(repoRoot, BLUE_REPOSITORY),
-      }),
-    ).toThrow(/Circular type dependency/);
+    const result = generateRepository({
+      repoRoot,
+      blueRepositoryPath: path.join(repoRoot, BLUE_REPOSITORY),
+    });
+
+    const coreTypes =
+      result.document.packages.find((pkg) => pkg.name === 'Core')?.types ?? [];
+    const a = coreTypes.find(
+      (type) => (type.content as { name?: string }).name === 'A',
+    );
+    const b = coreTypes.find(
+      (type) => (type.content as { name?: string }).name === 'B',
+    );
+    const aBlueId = a?.versions.at(-1)?.typeBlueId;
+    const bBlueId = b?.versions.at(-1)?.typeBlueId;
+
+    if (!a || !b) {
+      throw new Error('Expected cyclic test types to be generated.');
+    }
+
+    expect(aBlueId).toBeDefined();
+    expect(bBlueId).toBeDefined();
+    expect(aBlueId).not.toEqual(bBlueId);
+
+    const [masterBlueIdA, aSuffix] = (aBlueId ?? '').split('#');
+    const [masterBlueIdB, bSuffix] = (bBlueId ?? '').split('#');
+    expect(masterBlueIdA).toEqual(masterBlueIdB);
+    expect(new Set([aSuffix, bSuffix])).toEqual(new Set(['0', '1']));
+
+    const aReference = (a?.content as { ref?: { type?: { blueId?: string } } })
+      .ref?.type?.blueId;
+    const bReference = (b?.content as { ref?: { type?: { blueId?: string } } })
+      .ref?.type?.blueId;
+    expect(aReference).toEqual(`this#${bSuffix}`);
+    expect(bReference).toEqual(`this#${aSuffix}`);
+
+    const sortedContent = [
+      { suffix: aSuffix, content: a.content },
+      { suffix: bSuffix, content: b.content },
+    ]
+      .sort((left, right) =>
+        String(left.suffix).localeCompare(String(right.suffix)),
+      )
+      .map((entry) => entry.content);
+
+    expect(new Blue().calculateBlueIdSync(sortedContent)).toEqual(
+      masterBlueIdA,
+    );
+  });
+
+  it('supports single-type self references', () => {
+    const repoRoot = createRepo();
+    writeType(
+      repoRoot,
+      'Core',
+      'Node.blue',
+      `
+name: Node
+next:
+  type: Core/Node
+`,
+    );
+
+    const expectedMasterBlueId = new Blue().calculateBlueIdSync([
+      {
+        name: 'Node',
+        next: {
+          type: {
+            blueId: 'this#0',
+          },
+        },
+      },
+    ]);
+
+    const result = generateRepository({
+      repoRoot,
+      blueRepositoryPath: path.join(repoRoot, BLUE_REPOSITORY),
+    });
+    const node = result.document.packages
+      .find((pkg) => pkg.name === 'Core')
+      ?.types.find(
+        (type) => (type.content as { name?: string }).name === 'Node',
+      );
+
+    expect(node?.versions.at(-1)?.typeBlueId).toEqual(
+      `${expectedMasterBlueId}#0`,
+    );
+    expect(
+      (node?.content as { next?: { type?: { blueId?: string } } }).next?.type
+        ?.blueId,
+    ).toEqual('this#0');
   });
 
   it('rejects reserved value as an attribute declaration', () => {

--- a/libs/repository-generator/src/lib/core/blueIds.ts
+++ b/libs/repository-generator/src/lib/core/blueIds.ts
@@ -1,14 +1,39 @@
-import { Blue, createNodeProvider } from '@blue-labs/language';
+import { Blue, BlueNode, createNodeProvider } from '@blue-labs/language';
 import { OBJECT_CONTRACTS } from '@blue-labs/repository-contract';
 import type { JsonValue } from '@blue-labs/shared-utils';
-import { Alias, DiscoveredType, JsonMap } from './internalTypes';
+import {
+  Alias,
+  DiscoveredType,
+  JsonMap,
+  PackageTypeMap,
+} from './internalTypes';
 import { PRIMITIVE_BLUE_IDS, PRIMITIVE_TYPES } from './constants';
-import { cloneJson, isRecord } from './utils';
+import { cloneJson, isPlainObject, isRecord } from './utils';
 import { createRepositoryGeneratorMergingProcessor } from './mergingProcessor';
+import type { AliasComponent, DependencyGraph } from './graph';
+
+export const ZERO_BLUE_ID = '00000000000000000000000000000000000000000000';
+
+interface BlueIdContext {
+  blue: Blue;
+  contentByBlueId: Map<string, JsonValue>;
+}
+
+interface TypeStorageResult {
+  node: BlueNode;
+  storageContent: JsonMap;
+}
+
+interface PreservedTypeContent {
+  blueId: string;
+  content: JsonMap;
+}
 
 export function computeBlueIds(
-  topoOrder: Alias[],
+  componentOrder: AliasComponent[],
   discovered: Map<Alias, DiscoveredType>,
+  dependencyGraph: DependencyGraph,
+  previousTypes: PackageTypeMap,
 ): {
   aliasToBlueId: Map<Alias, string>;
   aliasToStorageContent: Map<Alias, JsonMap>;
@@ -17,40 +42,50 @@ export function computeBlueIds(
   const aliasToStorageContent = new Map<Alias, JsonMap>();
   const contentByBlueId = new Map<string, JsonValue>();
   const parserBlue = new Blue();
-  const provider = createNodeProvider((blueId) =>
-    lookupStorageContentByBlueId(contentByBlueId, blueId).map((content) =>
-      parserBlue.jsonValueToNode(content),
-    ),
-  );
+  const provider = createNodeProvider((blueId) => {
+    if (isCyclicPlaceholderBlueId(blueId)) {
+      return [new BlueNode().setReferenceBlueId(blueId)];
+    }
+    return lookupStorageContentByBlueId(contentByBlueId, blueId).map(
+      (content) => parserBlue.jsonValueToNode(content),
+    );
+  });
   const blue = new Blue({
     nodeProvider: provider,
     mergingProcessor: createRepositoryGeneratorMergingProcessor(),
   });
+  const context: BlueIdContext = { blue, contentByBlueId };
 
-  for (const alias of topoOrder) {
+  for (const component of componentOrder) {
+    if (isCyclicComponent(component, dependencyGraph)) {
+      computeCyclicComponent({
+        component,
+        discovered,
+        previousTypes,
+        aliasToBlueId,
+        aliasToStorageContent,
+        context,
+      });
+      continue;
+    }
+
+    const alias = component[0];
+    if (!alias) {
+      continue;
+    }
     const type = discovered.get(alias);
     if (!type) {
       continue;
     }
-    const substituted = substituteAliases(
-      cloneJson(type.content),
+
+    computeAcyclicType({
+      alias,
+      type,
+      previousTypes,
       aliasToBlueId,
-    ) as JsonMap;
-    const node = blue.jsonValueToNode(substituted);
-
-    const isPrimitive = PRIMITIVE_TYPES.has(type.typeName);
-    const blueId = isPrimitive
-      ? getPrimitiveBlueId(type.typeName)
-      : blue.calculateBlueIdSync(node);
-
-    const storageContent = blue.nodeToJson(node, 'official') as JsonMap;
-
-    aliasToBlueId.set(alias, blueId);
-    aliasToStorageContent.set(alias, storageContent);
-    if (!isPrimitive) {
-      contentByBlueId.set(blueId, storageContent);
-    }
-    blue.registerBlueIds({ [alias]: blueId });
+      aliasToStorageContent,
+      context,
+    });
   }
 
   return { aliasToBlueId, aliasToStorageContent };
@@ -100,17 +135,35 @@ function parseIndexedBlueId(
   return { baseBlueId, index };
 }
 
+function isCyclicPlaceholderBlueId(blueId: string): boolean {
+  return blueId === ZERO_BLUE_ID || /^this#\d+$/.test(blueId);
+}
+
 export function substituteAliases(
   content: JsonValue,
   aliasToBlueId: Map<Alias, string>,
   skipContracts = false,
   underContracts = false,
 ): JsonValue {
+  return substituteAliasesWithLookup(
+    content,
+    (alias) => aliasToBlueId.get(alias),
+    skipContracts,
+    underContracts,
+  );
+}
+
+function substituteAliasesWithLookup(
+  content: JsonValue,
+  lookupBlueId: (alias: Alias) => string | undefined,
+  skipContracts = false,
+  underContracts = false,
+): JsonValue {
   if (Array.isArray(content)) {
     return content.map((item) =>
-      substituteAliases(
+      substituteAliasesWithLookup(
         item as JsonValue,
-        aliasToBlueId,
+        lookupBlueId,
         skipContracts,
         underContracts,
       ),
@@ -142,7 +195,7 @@ export function substituteAliases(
         updated[key] = { blueId: primitiveId };
       } else {
         const alias = value as Alias;
-        const blueId = aliasToBlueId.get(alias);
+        const blueId = lookupBlueId(alias);
         if (!blueId) {
           throw new Error(`Missing BlueId for alias ${alias}.`);
         }
@@ -151,9 +204,9 @@ export function substituteAliases(
       continue;
     }
 
-    updated[key] = substituteAliases(
+    updated[key] = substituteAliasesWithLookup(
       value as JsonValue,
-      aliasToBlueId,
+      lookupBlueId,
       skipContracts,
       inContracts,
     );
@@ -161,6 +214,337 @@ export function substituteAliases(
 
   return updated;
 }
+
+function computeAcyclicType({
+  alias,
+  type,
+  previousTypes,
+  aliasToBlueId,
+  aliasToStorageContent,
+  context,
+}: {
+  alias: Alias;
+  type: DiscoveredType;
+  previousTypes: PackageTypeMap;
+  aliasToBlueId: Map<Alias, string>;
+  aliasToStorageContent: Map<Alias, JsonMap>;
+  context: BlueIdContext;
+}) {
+  const { node, storageContent } = buildStorageNode(
+    type,
+    (ref) => aliasToBlueId.get(ref),
+    context.blue,
+  );
+  const isPrimitive = PRIMITIVE_TYPES.has(type.typeName);
+  const calculatedBlueId = isPrimitive
+    ? getPrimitiveBlueId(type.typeName)
+    : context.blue.calculateBlueIdSync(node);
+  const preserved = getPreviousForUnchangedContent(
+    previousTypes,
+    type,
+    storageContent,
+  );
+  const blueId = preserved?.blueId ?? calculatedBlueId;
+  const finalStorageContent = preserved?.content ?? storageContent;
+
+  aliasToBlueId.set(alias, blueId);
+  aliasToStorageContent.set(alias, finalStorageContent);
+  if (!isPrimitive) {
+    context.contentByBlueId.set(blueId, finalStorageContent);
+  }
+  context.blue.registerBlueIds({ [alias]: blueId });
+}
+
+function computeCyclicComponent({
+  component,
+  discovered,
+  previousTypes,
+  aliasToBlueId,
+  aliasToStorageContent,
+  context,
+}: {
+  component: AliasComponent;
+  discovered: Map<Alias, DiscoveredType>;
+  previousTypes: PackageTypeMap;
+  aliasToBlueId: Map<Alias, string>;
+  aliasToStorageContent: Map<Alias, JsonMap>;
+  context: BlueIdContext;
+}) {
+  const componentAliases = new Set(component);
+  const originalIndexByAlias = new Map<Alias, number>();
+  component.forEach((alias, index) => originalIndexByAlias.set(alias, index));
+
+  const preliminary = component.map((alias) => {
+    const type = getDiscoveredType(discovered, alias);
+    const { node } = buildStorageNode(
+      type,
+      (ref) =>
+        componentAliases.has(ref) ? ZERO_BLUE_ID : aliasToBlueId.get(ref),
+      context.blue,
+    );
+    return {
+      alias,
+      preliminaryBlueId: context.blue.calculateBlueIdSync(node),
+    };
+  });
+
+  validateUniquePreliminaryBlueIds(preliminary);
+  preliminary.sort(comparePreliminaryDocuments);
+
+  const sortedIndexByAlias = new Map<Alias, number>();
+  preliminary.forEach(({ alias }, index) => {
+    sortedIndexByAlias.set(alias, index);
+  });
+
+  const storageByAlias = new Map<Alias, TypeStorageResult>();
+  for (const alias of component) {
+    const type = getDiscoveredType(discovered, alias);
+    const storage = buildStorageNode(
+      type,
+      (ref) => {
+        if (!componentAliases.has(ref)) {
+          return aliasToBlueId.get(ref);
+        }
+        const sortedIndex = sortedIndexByAlias.get(ref);
+        if (sortedIndex === undefined) {
+          throw new Error(`Failed to resolve cyclic reference ${ref}.`);
+        }
+        return `this#${sortedIndex}`;
+      },
+      context.blue,
+    );
+    storageByAlias.set(alias, storage);
+  }
+
+  const preservedByAlias = getPreservedCyclicContent(
+    component,
+    discovered,
+    previousTypes,
+    storageByAlias,
+  );
+  if (preservedByAlias) {
+    for (const alias of component) {
+      const preserved = preservedByAlias.get(alias);
+      if (!preserved) {
+        throw new Error(`Failed to preserve cyclic BlueId for type ${alias}.`);
+      }
+      aliasToBlueId.set(alias, preserved.blueId);
+      aliasToStorageContent.set(alias, preserved.content);
+      context.blue.registerBlueIds({ [alias]: preserved.blueId });
+    }
+    storeCyclicContentByBlueId(context.contentByBlueId, preservedByAlias);
+    return;
+  }
+
+  const sortedNodes = preliminary.map(({ alias }) => {
+    const storage = storageByAlias.get(alias);
+    if (!storage) {
+      throw new Error(`Failed to build cyclic content for type ${alias}.`);
+    }
+    return storage.node;
+  });
+  const sortedStorageContent = preliminary.map(({ alias }) => {
+    const storage = storageByAlias.get(alias);
+    if (!storage) {
+      throw new Error(`Failed to build cyclic content for type ${alias}.`);
+    }
+    return storage.storageContent;
+  });
+  const masterBlueId = context.blue.calculateBlueIdSync(sortedNodes);
+  context.contentByBlueId.set(masterBlueId, sortedStorageContent);
+
+  preliminary.forEach(({ alias }, index) => {
+    const storage = storageByAlias.get(alias);
+    if (!storage) {
+      throw new Error(`Failed to build cyclic content for type ${alias}.`);
+    }
+    const blueId = `${masterBlueId}#${index}`;
+    aliasToBlueId.set(alias, blueId);
+    aliasToStorageContent.set(alias, storage.storageContent);
+    context.blue.registerBlueIds({ [alias]: blueId });
+  });
+}
+
+function isCyclicComponent(
+  component: AliasComponent,
+  dependencyGraph: DependencyGraph,
+): boolean {
+  if (component.length > 1) {
+    return true;
+  }
+
+  const alias = component[0];
+  return alias ? (dependencyGraph.get(alias)?.has(alias) ?? false) : false;
+}
+
+function buildStorageNode(
+  type: DiscoveredType,
+  lookupBlueId: (alias: Alias) => string | undefined,
+  blue: Blue,
+): TypeStorageResult {
+  const substituted = substituteAliasesWithLookup(
+    cloneJson(type.content),
+    lookupBlueId,
+  ) as JsonMap;
+  const node = blue.jsonValueToNode(substituted);
+  return {
+    node,
+    storageContent: blue.nodeToJson(node, 'official') as JsonMap,
+  };
+}
+
+function getDiscoveredType(
+  discovered: Map<Alias, DiscoveredType>,
+  alias: Alias,
+): DiscoveredType {
+  const type = discovered.get(alias);
+  if (!type) {
+    throw new Error(`Unknown type alias ${alias}.`);
+  }
+  return type;
+}
+
+function getPreservedCyclicContent(
+  component: AliasComponent,
+  discovered: Map<Alias, DiscoveredType>,
+  previousTypes: PackageTypeMap,
+  storageByAlias: Map<Alias, TypeStorageResult>,
+): Map<Alias, PreservedTypeContent> | null {
+  const preservedByAlias = new Map<Alias, PreservedTypeContent>();
+  for (const alias of component) {
+    const type = getDiscoveredType(discovered, alias);
+    const storage = storageByAlias.get(alias);
+    if (!storage) {
+      throw new Error(`Failed to build cyclic content for type ${alias}.`);
+    }
+    const preserved = getPreviousForUnchangedContent(
+      previousTypes,
+      type,
+      storage.storageContent,
+    );
+    if (!preserved) {
+      return null;
+    }
+    preservedByAlias.set(alias, preserved);
+  }
+  return preservedByAlias;
+}
+
+function getPreviousForUnchangedContent(
+  previousTypes: PackageTypeMap,
+  type: DiscoveredType,
+  currentContent: JsonMap,
+): PreservedTypeContent | null {
+  const previousType = previousTypes.get(type.packageName)?.get(type.typeName);
+  const previousBlueId = previousType?.versions?.at(-1)?.typeBlueId;
+  if (
+    !previousBlueId ||
+    !previousType ||
+    !isPlainObject(previousType.content)
+  ) {
+    return null;
+  }
+
+  if (!jsonEquals(previousType.content, currentContent)) {
+    return null;
+  }
+
+  return {
+    blueId: previousBlueId,
+    content: cloneJson(previousType.content as JsonMap),
+  };
+}
+
+function storeCyclicContentByBlueId(
+  contentByBlueId: Map<string, JsonValue>,
+  preservedByAlias: Map<Alias, PreservedTypeContent>,
+) {
+  const grouped = new Map<string, Array<{ index: number; content: JsonMap }>>();
+
+  for (const { blueId, content } of preservedByAlias.values()) {
+    const parsed = parseIndexedBlueId(blueId);
+    if (!parsed || parsed.index === undefined) {
+      contentByBlueId.set(blueId, content);
+      continue;
+    }
+    const entries = grouped.get(parsed.baseBlueId) ?? [];
+    entries.push({ index: parsed.index, content });
+    grouped.set(parsed.baseBlueId, entries);
+  }
+
+  for (const [baseBlueId, entries] of grouped) {
+    const sorted = [...entries].sort((a, b) => a.index - b.index);
+    const content = sorted.map((entry, expectedIndex) => {
+      if (entry.index !== expectedIndex) {
+        throw new Error(
+          `Cyclic repository content for ${baseBlueId} is missing index ${expectedIndex}.`,
+        );
+      }
+      return entry.content;
+    });
+    contentByBlueId.set(baseBlueId, content);
+  }
+}
+
+function validateUniquePreliminaryBlueIds(
+  preliminary: Array<{ alias: Alias; preliminaryBlueId: string }>,
+) {
+  const aliasByBlueId = new Map<string, Alias>();
+  for (const document of preliminary) {
+    const existingAlias = aliasByBlueId.get(document.preliminaryBlueId);
+    if (existingAlias) {
+      throw new Error(
+        `Direct cyclic type set has ambiguous canonical ordering: ${existingAlias} and ${document.alias} share preliminary BlueId '${document.preliminaryBlueId}'.`,
+      );
+    }
+    aliasByBlueId.set(document.preliminaryBlueId, document.alias);
+  }
+}
+
+function comparePreliminaryDocuments(
+  left: { preliminaryBlueId: string },
+  right: { preliminaryBlueId: string },
+): number {
+  if (left.preliminaryBlueId < right.preliminaryBlueId) {
+    return -1;
+  }
+  if (left.preliminaryBlueId > right.preliminaryBlueId) {
+    return 1;
+  }
+  return 0;
+}
+
+function jsonEquals(a: JsonValue, b: JsonValue): boolean {
+  if (a === b) {
+    return true;
+  }
+
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) {
+      return false;
+    }
+    return a.every((item, index) => jsonEquals(item as JsonValue, b[index]));
+  }
+
+  if (isPlainObject(a) || isPlainObject(b)) {
+    if (!isPlainObject(a) || !isPlainObject(b)) {
+      return false;
+    }
+    const aKeys = Object.keys(a).sort();
+    const bKeys = Object.keys(b).sort();
+    if (aKeys.length !== bKeys.length) {
+      return false;
+    }
+    return aKeys.every(
+      (key, index) =>
+        key === bKeys[index] &&
+        jsonEquals(a[key] as JsonValue, b[key] as JsonValue),
+    );
+  }
+
+  return false;
+}
+
 function getPrimitiveBlueId(typeName: string): string {
   const primitiveId = PRIMITIVE_BLUE_IDS[typeName];
   if (!primitiveId) {

--- a/libs/repository-generator/src/lib/core/contractValidation.ts
+++ b/libs/repository-generator/src/lib/core/contractValidation.ts
@@ -2,7 +2,6 @@ import {
   BlueRepository,
   BlueRepositoryPackage,
   BlueTypeRuntimeMeta,
-  validateNoCycles,
   validateStableDoesNotDependOnDev,
 } from '@blue-labs/repository-contract';
 import type { JsonValue } from '@blue-labs/shared-utils';
@@ -24,7 +23,6 @@ export function validateWithContract(
     packages: buildContractPackages(packages, aliasToBlueId),
   };
 
-  validateNoCycles(contractRepo);
   validateStableDoesNotDependOnDev(contractRepo);
 }
 

--- a/libs/repository-generator/src/lib/core/graph.ts
+++ b/libs/repository-generator/src/lib/core/graph.ts
@@ -3,6 +3,8 @@ import { BLUE_TYPE_STATUS } from './constants';
 
 export type DependencyGraph = Map<Alias, Set<Alias>>;
 
+export type AliasComponent = Alias[];
+
 export function buildDependencyGraph(
   discovered: Map<Alias, DiscoveredType>,
 ): DependencyGraph {
@@ -58,27 +60,149 @@ export function topoSort(graph: DependencyGraph): Alias[] {
   return order;
 }
 
+export function stronglyConnectedComponents(
+  graph: DependencyGraph,
+): AliasComponent[] {
+  const components: AliasComponent[] = [];
+  const indexByAlias = new Map<Alias, number>();
+  const lowLinkByAlias = new Map<Alias, number>();
+  const stack: Alias[] = [];
+  const onStack = new Set<Alias>();
+  let nextIndex = 0;
+
+  const visit = (alias: Alias) => {
+    indexByAlias.set(alias, nextIndex);
+    lowLinkByAlias.set(alias, nextIndex);
+    nextIndex += 1;
+    stack.push(alias);
+    onStack.add(alias);
+
+    for (const dep of graph.get(alias) ?? []) {
+      if (!indexByAlias.has(dep)) {
+        visit(dep);
+        lowLinkByAlias.set(
+          alias,
+          Math.min(
+            lowLinkByAlias.get(alias) ?? 0,
+            lowLinkByAlias.get(dep) ?? 0,
+          ),
+        );
+        continue;
+      }
+      if (onStack.has(dep)) {
+        lowLinkByAlias.set(
+          alias,
+          Math.min(lowLinkByAlias.get(alias) ?? 0, indexByAlias.get(dep) ?? 0),
+        );
+      }
+    }
+
+    if (lowLinkByAlias.get(alias) !== indexByAlias.get(alias)) {
+      return;
+    }
+
+    const component: AliasComponent = [];
+    while (stack.length > 0) {
+      const item = stack.pop();
+      if (!item) {
+        break;
+      }
+      onStack.delete(item);
+      component.push(item);
+      if (item === alias) {
+        break;
+      }
+    }
+    components.push(component.sort((a, b) => a.localeCompare(b)));
+  };
+
+  for (const alias of graph.keys()) {
+    if (!indexByAlias.has(alias)) {
+      visit(alias);
+    }
+  }
+
+  return components;
+}
+
+export function topoSortComponents(graph: DependencyGraph): AliasComponent[] {
+  const components = stronglyConnectedComponents(graph);
+  const componentByAlias = new Map<Alias, number>();
+
+  components.forEach((component, componentIndex) => {
+    component.forEach((alias) => componentByAlias.set(alias, componentIndex));
+  });
+
+  const componentGraph = new Map<number, Set<number>>();
+  components.forEach((_component, index) =>
+    componentGraph.set(index, new Set()),
+  );
+
+  for (const [alias, deps] of graph) {
+    const source = componentByAlias.get(alias);
+    if (source === undefined) {
+      continue;
+    }
+    for (const dep of deps) {
+      const target = componentByAlias.get(dep);
+      if (target !== undefined && target !== source) {
+        componentGraph.get(source)?.add(target);
+      }
+    }
+  }
+
+  const order: number[] = [];
+  const visited = new Set<number>();
+
+  const visit = (componentIndex: number) => {
+    if (visited.has(componentIndex)) {
+      return;
+    }
+    visited.add(componentIndex);
+    for (const dep of componentGraph.get(componentIndex) ?? []) {
+      visit(dep);
+    }
+    order.push(componentIndex);
+  };
+
+  for (const componentIndex of componentGraph.keys()) {
+    visit(componentIndex);
+  }
+
+  return order.map((componentIndex) => components[componentIndex] ?? []);
+}
+
 export function enforceStableToDevRule(
   graph: DependencyGraph,
   discovered: Map<Alias, DiscoveredType>,
 ) {
   const memo = new Map<Alias, boolean>();
 
-  const reachesDev = (alias: Alias): boolean => {
+  const reachesDev = (alias: Alias, visiting = new Set<Alias>()): boolean => {
     if (memo.has(alias)) {
       return memo.get(alias) ?? false;
     }
+    if (visiting.has(alias)) {
+      return false;
+    }
+
+    visiting.add(alias);
     const deps = graph.get(alias) || new Set<Alias>();
     for (const dep of deps) {
       const depType = discovered.get(dep);
       if (!depType) {
         continue;
       }
-      if (depType.status === BLUE_TYPE_STATUS.Dev || reachesDev(dep)) {
+      if (
+        depType.status === BLUE_TYPE_STATUS.Dev ||
+        reachesDev(dep, visiting)
+      ) {
+        visiting.delete(alias);
         memo.set(alias, true);
         return true;
       }
     }
+    visiting.delete(alias);
     memo.set(alias, false);
     return false;
   };

--- a/libs/repository-generator/src/lib/generateRepository.ts
+++ b/libs/repository-generator/src/lib/generateRepository.ts
@@ -4,7 +4,7 @@ import { discoverTypes } from './core/discovery';
 import {
   buildDependencyGraph,
   enforceStableToDevRule,
-  topoSort,
+  topoSortComponents,
 } from './core/graph';
 import { computeBlueIds } from './core/blueIds';
 import {
@@ -34,13 +34,15 @@ export function generateRepository(
   validateStableRemoval(discoveredTypes, previousTypes);
 
   const dependencyGraph = buildDependencyGraph(discoveredTypes);
-  const topologicalOrder = topoSort(dependencyGraph);
+  const componentOrder = topoSortComponents(dependencyGraph);
 
   enforceStableToDevRule(dependencyGraph, discoveredTypes);
 
   const { aliasToBlueId, aliasToStorageContent } = computeBlueIds(
-    topologicalOrder,
+    componentOrder,
     discoveredTypes,
+    dependencyGraph,
+    previousTypes,
   );
 
   const nextRepoVersionIndex = previous
@@ -56,7 +58,10 @@ export function generateRepository(
   });
 
   const packages = finalizePackages(packagesMap);
-  const currentRepoBlueId = computeRepoBlueId(packages);
+  const currentRepoBlueId =
+    previous && packagesAreUnchanged(previous.packages, packages)
+      ? (previous.repositoryVersions.at(-1) ?? computeRepoBlueId(packages))
+      : computeRepoBlueId(packages);
 
   const { document, changed } = composeRepositoryDocument(
     packages,
@@ -92,4 +97,11 @@ export function generateRepository(
     yaml,
     existingYaml,
   };
+}
+
+function packagesAreUnchanged(
+  previousPackages: GenerateRepositoryResult['document']['packages'],
+  currentPackages: GenerateRepositoryResult['document']['packages'],
+): boolean {
+  return JSON.stringify(previousPackages) === JSON.stringify(currentPackages);
 }


### PR DESCRIPTION
- Improve test coverage for cyclic and self-referencing types
- Replace `topoSort` with `topoSortComponents` for resolving cyclic dependencies
- Preserve unchanged content and BlueIds during repository regeneration